### PR TITLE
Move Kubernetes annotations into a central spot

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ $ GIT_USER=<Your GitHub username> yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+
+### Partials
+
+`.mdx` files beginning with a `_` character are partials. These are useful for including a piece of content in multiple locations, such as tables of annotations that can be inserted both in their relevant section, as well as stored in a single reference location.

--- a/docs/install/kubernetes-sidecar/sidecar-annotations.mdx
+++ b/docs/install/kubernetes-sidecar/sidecar-annotations.mdx
@@ -1,0 +1,74 @@
+---
+title: Optional Sidecar Annotations
+---
+
+import SideCarAnnotations from '../../reference/_sidecar-annotations.mdx'
+
+How to customize your sidecar configuration with annotations.
+
+Here are additional annotation values for the sidecar:
+
+<SideCarAnnotations />
+
+
+### Capture Mode
+
+Depending upon your environment you may want to customize the capture mode being used:
+
+* `proxy` is the default and should be used if there is no other sidecar.
+* `wasm` is what should be used if you have an istio sidecar already.
+
+### TLS Inbound Interception
+
+The sidecar will be listening for incoming transactions, and must present to the client the correct certificate. Because you already have TLS configured, the cert files you are using must be provided to the sidecar. There are the fields:
+
+* &#x20;**tlsinsecret** (required) is the name of the Kubernetes secret
+* &#x20;**tlsinprivate** (optional) is the filename of the private key inside the secret (default: tls.key)
+* &#x20;**tlsinpublic** (optional) is the filename of the public cert inside the secret (default: tls.crt)
+
+When your deployment is injected, the sidecar will have an extra environment variable **TLS_IN_UNWRAP=true**, **TLS_IN_PUBLIC_KEY**, **TLS_IN_PRIVATE_KEY** and a volume mount to access the files from the provided secret.
+
+```
+  annotations:
+    sidecar.speedscale.com/inject: "true"
+    sidecar.speedscale.com/tls: "all"
+    sidecar.speedscale.com/tlsinsecret: "my-tls-secret"
+    sidecar.speedscale.com/tlsinprivate: "tls.key"
+    sidecar.speedscale.com/tlsinpublic: "tls.crt"
+```
+
+### TLS Outbound Interception
+
+To unwrap outbound TLS calls there are multiple steps required:
+
+* Configure the sidecar to the TLS "all" setting.
+* Configure your application to trust the new TLS Certificates
+
+When your deployment is injected, the sidecar will have an extra environment variable **TLS_OUT_UNWRAP=true** and a volume mount to access the files from the **ss-certs** secret. The operator will automatically create a secret named **ss-certs** and put into the namespace. All that is required is to add this annotation to your deployment:
+
+```
+  annotations:
+    sidecar.speedscale.com/inject: "true"
+    sidecar.speedscale.com/tls: "all"
+```
+
+### Mutual Authentication for Outbound Calls
+
+If your backend system requires [**Mutual Authentication**](https://tools.ietf. Org/html/rfc8120) (aka Mutual TLS or 2-Way TLS), this requires configuring the sidecar with an additional X509 key pair. During the TLS handshake, the backend system will request a Client Certificate. This is the certificate that goproxy will present. There are the fields:
+
+* &#x20;**tlsmutualsecret** (required) is the name of the Kubernetes secret
+* &#x20;**tlsmutualprivate** (optional) is the filename of the private key inside the secret (default: tls.key)
+* &#x20;**tlsmutualpublic** (optional) is the filename of the public cert inside the secret (default: tls.crt)
+
+When your deployment is injected, the sidecar will have extra environment variables **TLS_MUTUAL_PUBLIC_KEY** and **TLS_MUTUAL_PRIVATE_KEY** and a volume mount to access the files from the provided secret. You must provide a Kubernetes secret that has the TLS private key and public cert. The name of the secret and the names of the files can be provided to **operator** to inject automatically.
+
+```
+  annotations:
+    sidecar.speedscale.com/inject: "true"
+    sidecar.speedscale.com/tls: "all"
+    sidecar.speedscale.com/tlsmutualsecret: "my-tls-secret"
+    sidecar.speedscale.com/tlsmutualprivate: "tls.key"
+    sidecar.speedscale.com/tlsmutualpublic: "tls.crt"
+```
+
+####

--- a/docs/reference/_replay-annotations.mdx
+++ b/docs/reference/_replay-annotations.mdx
@@ -1,0 +1,9 @@
+| Annotation                             | Description                                                                                                                                           |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test.speedscale.com/tag`              | Link a unique tag, build hash, etc. to the Speedscale report. That way you can connect the report results to the version of the code that was tested. |
+| `test.speedscale.com/deployResponder`  | Set to `"true"` to deploy the responder. (default: false)                                                                                             |
+| `test.speedscale.com/deployGenerator`  | Set to `"false"` to not deploy the generator (default: true)                                                                                          |
+| `test.speedscale.com/secrets`          | Use this setting to provide a list of secrets for the replay system to load (ex: JWT passwords).                                                      |
+| `test.speedscale.com/cleanup`          | Setting to `"false"`will not remove the system under test.                                                                                            |
+| `test.speedscale.com/logCollection`    | Set to `"true"` to collect logs from the system under test (default: false).                                                                          |
+| `test.speedscale.com/responderLowData` | Set to "true" to force the responder into a high efficiency/low data output mode. This is ideal for high volume performance tests.                    |

--- a/docs/reference/_sidecar-annotations.mdx
+++ b/docs/reference/_sidecar-annotations.mdx
@@ -1,10 +1,3 @@
-
-# Optional Sidecar Annotations
-
-How to customize your sidecar configuration with annotations.
-
-Here are additional annotation values for the sidecar:
-
 | Annotation                                  | Description |
 | ------------------------------------------- | ----------- |
 | `sidecar.speedscale.com/inject`             | Add the sidecar to your: deployment, job, stateful set or daemon set. |
@@ -29,65 +22,3 @@ Here are additional annotation values for the sidecar:
 | `sidecar.speedscale.com/ignoreDstIPs`       | Comma separated string of destination IPv4 addresses or IPv4 CIDR blocks for outbound traffic that should <strong>not</strong> be routed through the proxy. Only valid if `captureMode` is `proxy` and `proxyType` is `transparent`, ignored otherwise. Wildcards are not currently supported. Example: `sidecar.speedscale.com/ignoreDstIPs: "10.10.0.40,10.200.10.0/24"`|
 | `sidecar.speedscale.com/ignoreDstHosts`     | Comma separated string of destination hostnames for outbound traffic that should <strong>not</strong> be routed through the proxy. Only valid if `captureMode` is `proxy` and `proxyType` is `transparent`, ignored otherwise. Wildcards are not currently supported. Example: `sidecar.speedscale.com/ignoreDstHosts: "example.com,mysvc.internal"`|
 |                                             |             |
-
-### Capture Mode
-
-Depending upon your environment you may want to customize the capture mode being used:
-
-* `proxy` is the default and should be used if there is no other sidecar.
-* `wasm` is what should be used if you have an istio sidecar already.
-
-### TLS Inbound Interception
-
-The sidecar will be listening for incoming transactions, and must present to the client the correct certificate. Because you already have TLS configured, the cert files you are using must be provided to the sidecar. There are the fields:
-
-* &#x20;**tlsinsecret** (required) is the name of the Kubernetes secret
-* &#x20;**tlsinprivate** (optional) is the filename of the private key inside the secret (default: tls.key)
-* &#x20;**tlsinpublic** (optional) is the filename of the public cert inside the secret (default: tls.crt)
-
-When your deployment is injected, the sidecar will have an extra environment variable **TLS_IN_UNWRAP=true**, **TLS_IN_PUBLIC_KEY**, **TLS_IN_PRIVATE_KEY** and a volume mount to access the files from the provided secret.
-
-```
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls: "all"
-    sidecar.speedscale.com/tlsinsecret: "my-tls-secret"
-    sidecar.speedscale.com/tlsinprivate: "tls.key"
-    sidecar.speedscale.com/tlsinpublic: "tls.crt"
-```
-
-### TLS Outbound Interception
-
-To unwrap outbound TLS calls there are multiple steps required:
-
-* Configure the sidecar to the TLS "all" setting.
-* Configure your application to trust the new TLS Certificates
-
-When your deployment is injected, the sidecar will have an extra environment variable **TLS_OUT_UNWRAP=true** and a volume mount to access the files from the **ss-certs** secret. The operator will automatically create a secret named **ss-certs** and put into the namespace. All that is required is to add this annotation to your deployment:
-
-```
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls: "all"
-```
-
-### Mutual Authentication for Outbound Calls
-
-If your backend system requires [**Mutual Authentication**](https://tools.ietf. Org/html/rfc8120) (aka Mutual TLS or 2-Way TLS), this requires configuring the sidecar with an additional X509 key pair. During the TLS handshake, the backend system will request a Client Certificate. This is the certificate that goproxy will present. There are the fields:
-
-* &#x20;**tlsmutualsecret** (required) is the name of the Kubernetes secret
-* &#x20;**tlsmutualprivate** (optional) is the filename of the private key inside the secret (default: tls.key)
-* &#x20;**tlsmutualpublic** (optional) is the filename of the public cert inside the secret (default: tls.crt)
-
-When your deployment is injected, the sidecar will have extra environment variables **TLS_MUTUAL_PUBLIC_KEY** and **TLS_MUTUAL_PRIVATE_KEY** and a volume mount to access the files from the provided secret. You must provide a Kubernetes secret that has the TLS private key and public cert. The name of the secret and the names of the files can be provided to **operator** to inject automatically.
-
-```
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls: "all"
-    sidecar.speedscale.com/tlsmutualsecret: "my-tls-secret"
-    sidecar.speedscale.com/tlsmutualprivate: "tls.key"
-    sidecar.speedscale.com/tlsmutualpublic: "tls.crt"
-```
-
-####

--- a/docs/reference/kubernetes-annotations.md
+++ b/docs/reference/kubernetes-annotations.md
@@ -1,0 +1,20 @@
+---
+title: Kubernetes Annotations
+---
+
+import SidecarAnnotations from './_sidecar-annotations.mdx'
+import ReplayAnnotations from './_replay-annotations.mdx'
+
+Below are all the relevant Kubernetes annotations for Speedscale.
+
+## Sidecar Annotations
+
+These annotations relate to the proxy sidecar that Speedscale attaches to your workload.
+
+<SidecarAnnotations />
+
+## Replay Annotations
+
+These annotations control traffic replay for your workload.
+
+<ReplayAnnotations />

--- a/docs/replay/replay-snapshot/optional-replay-annotations.mdx
+++ b/docs/replay/replay-snapshot/optional-replay-annotations.mdx
@@ -1,23 +1,17 @@
 ---
 sidebar_position: 1 
+title: Optional Replay Annotations
 ---
 
-# Optional Replay Annotations
+import ReplayAnnotations from '../../reference/_replay-annotations.mdx'
 
 Just add annotations to your deployment and the operator will take care of the
 rest.
 
 Here are additional annotations for customizing your replay
 
-| Annotation                             | Description                                                                                                                                           |
-| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `test.speedscale.com/tag`              | Link a unique tag, build hash, etc. to the Speedscale report. That way you can connect the report results to the version of the code that was tested. |
-| `test.speedscale.com/deployResponder`  | Set to `"true"` to deploy the responder. (default: false)                                                                                             |
-| `test.speedscale.com/deployGenerator`  | Set to `"false"` to not deploy the generator (default: true)                                                                                          |
-| `test.speedscale.com/secrets`          | Use this setting to provide a list of secrets for the replay system to load (ex: JWT passwords).                                                      |
-| `test.speedscale.com/cleanup`          | Setting to `"false"`will not remove the system under test.                                                                                            |
-| `test.speedscale.com/logCollection`    | Set to `"true"` to collect logs from the system under test (default: false).                                                                          |
-| `test.speedscale.com/responderLowData` | Set to "true" to force the responder into a high efficiency/low data output mode. This is ideal for high volume performance tests.                    |
+<ReplayAnnotations />
+
 
 ### Tag Annotation
 


### PR DESCRIPTION
With operator v2 coming, it would be nice to have a place to gather
annotations and labels, as well as use them in context with their
feature set.

This change moves the markdown tables into mdx partials, and includes
them in the relevant spots.

Signed-off-by: Nolan Brubaker <nolan@speedscale.com>