### PR TITLE
Update image tags in documentation

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -1,4 +1,3 @@
-
 # FAQ
 
 You've got questions, we've got answers.
@@ -273,7 +272,7 @@ spec:
           value: /etc/ssl/speedscale
         - name: TLS_AUTODISCOVERY
           value: "false"
-        image: gcr.io/speedscale/goproxy:v1.3.254
+        image: gcr.io/speedscale/goproxy:v2.3.586
         imagePullPolicy: Always
         name: speedscale-goproxy
         ports:
@@ -316,7 +315,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: gcr.io/speedscale/goproxy:v1.3.254
+        image: gcr.io/speedscale/goproxy:v2.3.586
         imagePullPolicy: Always
         name: speedscale-initproxy-iptables
         resources:
@@ -364,7 +363,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: gcr.io/speedscale/goproxy:v1.3.254
+        image: gcr.io/speedscale/goproxy:v2.3.586
         imagePullPolicy: Always
         name: speedscale-initproxy-smartdns
         resources:
@@ -393,7 +392,7 @@ spec:
 
 You must delete these two sections:
 ```yaml
-        image: gcr.io/speedscale/goproxy:v1.3.254
+        image: gcr.io/speedscale/goproxy:v2.3.586
         imagePullPolicy: Always
         name: speedscale-goproxy
         ports:
@@ -436,7 +435,7 @@ You must delete these two sections:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: gcr.io/speedscale/goproxy:v1.3.254
+        image: gcr.io/speedscale/goproxy:v2.3.586
         imagePullPolicy: Always
         name: speedscale-initproxy-iptables
         resources:
@@ -484,7 +483,7 @@ You must delete these two sections:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: gcr.io/speedscale/goproxy:v1.3.254
+        image: gcr.io/speedscale/goproxy:v2.3.586
         imagePullPolicy: Always
         name: speedscale-initproxy-smartdns
         resources:
@@ -507,37 +506,3 @@ You must delete these two sections:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
 ```
-
-Never hesitate to reach out to Speedscale support if you need help. We work hard to automate this process but we can't always prevent helm from crashing or other gremlins from pulling levers in your cluster.
-
-### How often should I plan to upgrade Speedscale in my cluster?
-
-Speedscale typically releases new customer-side components weekly or more. By default, the Speedscale [helm](https://github.com/speedscale/operator-helm/blob/main/README.md) chart uses a pinned patch version that will not automatically upgrade. However, if you would like to always use the latest version you can instead pin to the minor version and set your image pull policy to pull more frequently. This will ensure you have the latest non-breaking version installed.
-
-If you plan to manually upgrade, we recommend doing so at least monthly.
-
-### Does Speedscale support sampling traffic?
-
-Yes, but maybe not in the way you expect.
-
-Sampling is a technique for capturing a subset of application traffic.  This is
-an effective way to reduce the amount of data that is sent to Speedscale or
-limit the blast radius of an infrasructure change when validating the Speedscale
-sidecar proxy, called [goproxy](/reference/glossary/#goproxy).
-
-Speedscale does not support capturing a subset of traffic from a single goproxy
-instance, but you can run goproxy on less of your nodes.  See [pod
-sampling](/guides/production-readiness/#pod-sampling).
-
-"But why doesn't Speedscale let me add the sidecar to all pods and choose a
-percentage of traffic to sample?"  Glad you asked.  That's a valid question
-considering this is how other types of data (like
-[tracing](https://en.wikipedia.org/wiki/Tracing_(software))) handle sampling.
-Unfortunately, this approach doesn't work well for traffic capture.  Network
-traffic is sent as part of a connection between a client and server, between the
-user and your application, and having only part of that user's session doesn't
-make sense.  Let's say you have an online store.  Your customer looks at a
-product, links to a similar product from that page, adds to the cart, and then
-checks out.  If Speedscale only captures the "add to cart" request the data is
-incomplete, out of context, and not very useful.
-

--- a/docs/setup/install/azure.md
+++ b/docs/setup/install/azure.md
@@ -135,7 +135,7 @@ spec:
         app: goproxy-capture
     spec:
       containers:
-        - image: gcr.io/speedscale/goproxy:v1.3
+        - image: gcr.io/speedscale/goproxy:v2.3.586
           imagePullPolicy: Always
           name: goproxy-capture
           env:

--- a/docs/setup/install/beanstalk.md
+++ b/docs/setup/install/beanstalk.md
@@ -109,7 +109,7 @@ services:
     volumes:
       - ./certs:/etc/ssl/capture
   goproxy:
-    image: gcr.io/speedscale/goproxy:v1.2
+    image: gcr.io/speedscale/goproxy:v2.3.586
     ports:
       - 80:4143
     volumes:
@@ -129,17 +129,16 @@ services:
       - APP_POD_NAME=notifications
       - APP_POD_NAMESPACE=notifications
   forwarder:
-    image: gcr.io/speedscale/forwarder:v1.2
+    image: gcr.io/speedscale/forwarder:v2.3.586
     env_file:
       - .env
     environment:
       - CLUSTER_NAME=beanstalk
-```
 
 generator snippet
 ```yaml
   generator:
-    image: gcr.io/speedscale/generator:v1.2
+    image: gcr.io/speedscale/generator:v2.3.586
     restart: "no"
     env_file:
       - .env

--- a/docs/setup/install/cloudrun.md
+++ b/docs/setup/install/cloudrun.md
@@ -166,7 +166,7 @@ spec:
         app: goproxy-capture
     spec:
       containers:
-        - image: gcr.io/speedscale/goproxy:v1.3
+        - image: gcr.io/speedscale/goproxy:v2.3.586
           imagePullPolicy: Always
           name: goproxy-capture
           env:

--- a/docs/setup/install/ecs.md
+++ b/docs/setup/install/ecs.md
@@ -37,7 +37,7 @@ resource "aws_ecs_task_definition" "forwarder" {
   container_definitions = jsonencode([
     {
       name      = "forwarder"
-      image     = "gcr.io/speedscale/forwarder:v1.2"
+      image     = "gcr.io/speedscale/forwarder:v2.3.586"
       essential = true
       healthCheck = {
         command = [
@@ -230,7 +230,7 @@ resource "aws_ecs_task_definition" "with-speedscale" {
     },
     {
       name      = "goproxy"
-      image     = "gcr.io/speedscale/goproxy:v1.2"
+      image     = "gcr.io/speedscale/goproxy:v2.3.586"
       essential = true
       logConfiguration = {
         logDriver = "awslogs",
@@ -363,7 +363,7 @@ resource "aws_ecs_task_definition" "generator" {
   container_definitions = jsonencode([
     {
       name      = "generator"
-      image     = "gcr.io/speedscale/generator:v1.4"
+      image     = "gcr.io/speedscale/generator:v2.3.586"
       essential = true
       logConfiguration = {
         logDriver = "awslogs",
@@ -521,7 +521,7 @@ resource "aws_ecs_task_definition" "with-responder" {
     },
     {
       name      = "responder"
-      image     = "gcr.io/speedscale/responder:v1.4"
+      image     = "gcr.io/speedscale/responder:v2.3.586"
       essential = true
       healthCheck = {
         command = [


### PR DESCRIPTION
A session was conducted to update `gcr.io` image references within the documentation repository. The objective was to standardize Speedscale component image tags to the latest version, `v2.3.586`, as identified in the release notes.

Updates were applied to:
*   `docs/reference/faq.md`: `gcr.io/speedscale/goproxy` from `v1.3.254` to `v2.3.586`.
*   `docs/setup/install/azure.md`: `gcr.io/speedscale/goproxy` from `v1.3` to `v2.3.586`.
*   `docs/setup/install/beanstalk.md`: `gcr.io/speedscale/goproxy`, `gcr.io/speedscale/forwarder`, and `gcr.io/speedscale/generator` from `v1.2` to `v2.3.586`.
*   `docs/setup/install/cloudrun.md`: `gcr.io/speedscale/goproxy` from `v1.3` to `v2.3.586`.
*   `docs/setup/install/ecs.md`: `gcr.io/speedscale/forwarder`, `gcr.io/speedscale/goproxy`, `gcr.io/speedscale/generator`, and `gcr.io/speedscale/responder` from `v1.2` or `v1.4` to `v2.3.586`.

Demo application images (`gcr.io/speedscale-demos/*`), `gcr.io/speedscale/redis` (lacking a version tag), and generic example images were intentionally left unchanged, as they are not Speedscale core components requiring version updates.