### PR TITLE
Update tutorial.md

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -197,16 +197,25 @@ export TEST_REPORT_ID=$(uuidgen |  tr '[:upper:]' '[:lower:]'); docker compose -
 
 1. Click the `Save to Tests/Mocks` button in the top right. All the default settings are ok here. You can find more detailed instructions in the [Create a Snapshot](./guides/creating-a-snapshot.md) section.
 2. Once you see the Snapshot summary, copy the snapshot ID from the URL or by clicking the `Copy Snapshot ID` option from the three dot menu.
-3. Run:
+3. This is how you run the application:
 
 ```bash
 make local-replay
 ```
 
-4. Replace `SNAPSHOT_ID` and run:
-
+4. In another terminal window, download the modified snapshot locally with:
 ```bash
-speedctl replay SNAPSHOT_ID --test-config-id=standard  --custom-url='http://localhost:8080'
+proxymock cloud pull snapshot SNAPSHOT_ID
+```
+
+5. Now you can run the mock server like so:
+```bash
+proxymock mock --in proxymock/snapshot-SNAPSHOT_ID
+```
+
+6. In a third terminal window, you can run the test replay:
+```bash
+proxymock replay --in proxymock/snapshot-SNAPSHOT_ID
 ```
 
 </TabItem>
@@ -343,7 +352,7 @@ services:
 
 <TabItem value="Local">
 
-Run the `speedctl capture` command with the additional flag `--dlp-config standard`.
+When running `proxymock` the files are stored locally but don't run through data loss prevention.
 
 </TabItem>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Revamps Local replay steps to use proxymock (pull/mock/replay) and notes that proxymock local files bypass DLP.
> 
> - **Tutorial updates**
>   - **Replay (Local)**:
>     - Replace `speedctl replay` flow with `proxymock` workflow: pull snapshot (`proxymock cloud pull snapshot SNAPSHOT_ID`), run mock server (`proxymock mock --in proxymock/snapshot-SNAPSHOT_ID`), and run replay (`proxymock replay --in proxymock/snapshot-SNAPSHOT_ID`).
>     - Clarify step descriptions and terminal window usage.
>   - **DLP (Local)**:
>     - Replace instruction to run `speedctl capture --dlp-config standard` with note that `proxymock` stores files locally and does not apply DLP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9565bea312e255c915e9cf426389ae0a5f860933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->