### PR TITLE
Add CustomerOS and add Datadog RUM tracking

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,6 @@ const config = {
   themes: ["@docusaurus/theme-mermaid"],
 
   plugins: [
-    "docusaurus-plugin-hubspot",
     [
       "@docusaurus/plugin-google-tag-manager",
       {
@@ -577,6 +576,41 @@ const config = {
     ],
   ],
 
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {
+        id: 'customeros-metrics',
+        type: 'text/javascript',
+      },
+      innerHTML: `(function (c, u, s, t, o, m, e, r, O, S) {var customerOS = document.createElement(s);customerOS.src = u;customerOS.async = true;(document.body || document.head).appendChild(customerOS);})(window, "https://cosxuaidt.speedscale.com/analytics-0.1.js", "script");`,
+    },
+    {
+      tagName: 'script',
+      attributes: {
+        type: 'text/javascript',
+      },
+      innerHTML: `(function(h,o,u,n,d) {
+    h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
+    d=o.createElement(u);d.async=1;d.src=n
+    n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM')
+  window.DD_RUM.onReady(function() {
+    window.DD_RUM.init({
+      clientToken: 'pub2019c1346c7ab4080cf258cb4d94d3c9',
+      applicationId: '41389bb5-58c1-4216-b37d-b0cf3f004bb9',
+      site: 'datadoghq.com',
+      service: 'docs.speedscale.com',
+      env: 'production',
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 0,
+      trackBfcacheViews: true,
+      defaultPrivacyLevel: 'mask-user-input',
+    });
+  })`,
+    },
+  ],
+
   clientModules: [],
 
   presets: [
@@ -607,9 +641,6 @@ const config = {
         // Public API key: it is safe to commit it
         apiKey: "96ea3a26c0551c1f0e9729366ef87cd5",
         indexName: "speedscale",
-      },
-      hubspot: {
-        accountId: 7910857,
       },
       colorMode: {
         disableSwitch: true,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "algoliasearch-helper": "^3.22.6",
     "clsx": "^2.0.0",
     "csv-parser": "^3.0.0",
-    "docusaurus-plugin-hubspot": "^1.0.0",
     "dompurify": "^3.2.4",
     "estree-util-value-to-estree": "^3.3.3",
     "prism-react-renderer": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4494,11 +4494,6 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-docusaurus-plugin-hubspot@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/docusaurus-plugin-hubspot/-/docusaurus-plugin-hubspot-1.0.1.tgz#a68d09e048dd686ddeda97a53eb3d48cd9beaac8"
-  integrity sha512-sX/6dMQ1nkh5sneNLIdOqrZdzFDlxBGcFwGjiQBS3z3JH87UinlSSVWpzCHU/PFKCAX3cqQSTjZwA/JP5dLPzQ==
-
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"


### PR DESCRIPTION
## Summary
- Remove HubSpot tracking plugin (it is already in GTM)
- Add CustomerOS metrics
- Add Datadog RUM tracking for enhanced monitoring
- Session replay disabled in Datadog (remains with PostHog only)

## Changes
- Removed `docusaurus-plugin-hubspot` dependency
- Removed HubSpot configuration from `themeConfig`
- Added CustomerOS metrics tracker via `headTags`
- Added Datadog RUM tracker via `headTags` with session replay disabled

## Test plan
- [x] Build passes successfully
- [ ] Verify CustomerOS metrics appear in production
- [ ] Verify Datadog RUM data appears in Datadog dashboard
- [ ] Confirm HubSpot scripts are still working from GTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)