### PR TITLE
[SPD-11396] Add selective mocking cross-reference to mocking concepts page

### DIFF
--- a/docs/guides/mocking/mocks.md
+++ b/docs/guides/mocking/mocks.md
@@ -22,5 +22,5 @@ For these reasons and others, many organizations have moved away from the entire
 In the following sections we will discuss Speedscale's unique approach to service virtualization as well as explore common usage patterns.
 
 :::tip Selective mocking via CLI
-Starting with the latest `speedctl`, you can selectively control which outbound services are mocked during a replay. Use `--mock-only` to mock only specific backends (e.g., rate-limited APIs or third-party services with idempotent transactions), or `--mock-except` to mock everything except services you want to call live. You can also exclude specific inbound services from replay with `--exclude-in`. See [Replay With speedctl — Controlling Outbound Mocks](/guides/replay/via-speedctl#controlling-outbound-mocks) for full details.
+Use `--mock-only` to mock only specific backends (e.g., rate-limited APIs or third-party services with idempotent transactions), or `--mock-except` to mock everything except services you want to call live. You can also exclude specific inbound services from replay with `--exclude-in`. See [Replay With speedctl — Controlling Outbound Mocks](/guides/replay/via-speedctl#controlling-outbound-mocks) for full details.
 :::

--- a/docs/guides/mocking/mocks.md
+++ b/docs/guides/mocking/mocks.md
@@ -20,3 +20,7 @@ For these reasons and others, many organizations have moved away from the entire
 * automatically re-route the network and TLS so no app changes are made
 
 In the following sections we will discuss Speedscale's unique approach to service virtualization as well as explore common usage patterns.
+
+:::tip Selective mocking via CLI
+Starting with the latest `speedctl`, you can selectively control which outbound services are mocked during a replay. Use `--mock-only` to mock only specific backends (e.g., rate-limited APIs or third-party services with idempotent transactions), or `--mock-except` to mock everything except services you want to call live. You can also exclude specific inbound services from replay with `--exclude-in`. See [Replay With speedctl — Controlling Outbound Mocks](/guides/replay/via-speedctl#controlling-outbound-mocks) for full details.
+:::


### PR DESCRIPTION
Adds a tip admonition to the Mocking & Service Virtualization concepts page linking to the new `--mock-only`, `--mock-except`, and `--exclude-in` flags documented in the speedctl replay guide.

This helps users discover selective mocking capabilities from the conceptual entry point, not just the CLI reference.

Related to SPD-11396.