### PR TITLE
[SPD-11587] docs: fix proxymock inspect syntax

### DIFF
--- a/docs/proxymock/aws/dynamodb.md
+++ b/docs/proxymock/aws/dynamodb.md
@@ -20,7 +20,7 @@ proxymock import --file default.jsonl
 Take note of the snapshot ID that is returned. Run the following command to view the mock:
 
 ```bash
-proxymock inspect snapshot <snapshot-id>
+proxymock inspect --snapshot <snapshot-id>
 ```
 
 ![list](./dynamodb/dynamodb-list.png)


### PR DESCRIPTION
## Summary
Update the DynamoDB proxymock docs page to use the current `proxymock inspect --snapshot <snapshot-id>` syntax.

## Why
The CLI now expects the `--snapshot` flag, but this page still showed the old `inspect snapshot` form and made the command look broken.

## Verification
- `thoughts/scripts/verify-proxymock-inspect-docs.sh`
- `npm --prefix /Users/rachel/code/docs/SPD-11587-proxymock-inspect-docs run build`
- `npm --prefix /Users/rachel/code/proxymock-io/SPD-11587-proxymock-inspect-docs run build`
- `npm --prefix /Users/rachel/code/proxymock-io/SPD-11587-proxymock-inspect-docs run verify`

Jira: SPD-11587
