### PR TITLE
[SPD-11588] docs: fix stale speedctl/proxymock CLI examples

### DIFF
--- a/docs/guides/browser.md
+++ b/docs/guides/browser.md
@@ -19,12 +19,13 @@ Now that you have `speedctl` installed, make sure you have TLS certificates crea
 ls -al ~/.speedscale/certs
 ```
 
-If you have certificates, great! If you got an error `No such file or directory` then you can create the certificates with the following steps. First create the directory, then create the certificates in that directory.
+If you have certificates, great! If you got an error `No such file or directory` then generate the default Speedscale certificates:
 
 ```
-mkdir ~/.speedscale/certs
-speedctl create certs --output-dir ~/.speedscale/certs
+speedctl create certs
 ```
+
+This writes `tls.crt` and `tls.key` to `~/.speedscale/certs`.
 
 You should be able to see your certs are in the directory:
 

--- a/docs/guides/compare-rrpairs.md
+++ b/docs/guides/compare-rrpairs.md
@@ -45,24 +45,17 @@ By default, the comparison shows all RRPairs. Use the filter controls to narrow 
 
 ## Comparing via the CLI
 
-The proxymock CLI includes a `compare` command for diffing RRPair files locally:
+The proxymock CLI includes a `files compare` command for diffing RRPair files locally when they share `refUuid` relationships - for example, traffic recorded with proxymock and the replay results generated from it:
 
 ```bash
-proxymock compare --baseline ./dataset-a --target ./dataset-b
+proxymock files compare --in recorded/ --in replayed/
 ```
 
-This compares RRPair files in the two directories and outputs a summary of differences. Options include:
-
-- `--output json` — output the diff as structured JSON for programmatic use
-- `--ignore-headers` — exclude headers from the comparison (useful when headers contain timestamps or request IDs)
-- `--ignore-fields` — exclude specific JSON fields from body comparison
+This compares RRPair files from the supplied directories or files and exits non-zero when differences are found. Add more verbosity if you want a more detailed diff:
 
 ```bash
-# Compare only response bodies, ignoring timestamps
-proxymock compare \
-  --baseline ./before-deploy \
-  --target ./after-deploy \
-  --ignore-fields "$.timestamp,$.requestId"
+# Compare recorded traffic and replay results with very verbose output
+proxymock files compare --in recorded/ --in replayed/ -vvv
 ```
 
 ## Interpreting Diffs
@@ -81,7 +74,7 @@ Not all body changes are regressions. Common expected changes include:
 - **Request IDs and correlation IDs** — unique per request
 - **Ordering** — array elements may appear in a different order
 
-Use the `--ignore-fields` flag (CLI) or the field ignore controls (dashboard) to suppress expected noise.
+If you expect noisy fields such as timestamps or request IDs, normalize that data before comparing, or use the field ignore controls in the dashboard.
 
 ### Latency Changes
 

--- a/docs/guides/dlp/cli-reference.md
+++ b/docs/guides/dlp/cli-reference.md
@@ -14,43 +14,43 @@ This section provides CLI reference documentation for managing DLP rules using `
 
 ## Pulling DLP Rules
 
-Use `speedctl pull dlp-rule` to download a DLP rule from Speedscale to your local machine.
+Use `speedctl pull dlp` to download a DLP rule from Speedscale to your local machine.
 
 ```bash
-speedctl pull dlp-rule <rule-id>
+speedctl pull dlp <rule-id>
 ```
 
-By default, the rule is downloaded to `~/.speedscale/data/dlp-rules/<rule-id>.json`.
+By default, the rule is downloaded to `~/.speedscale/data/dlp/<rule-id>.json`.
 
 ### Example
 
 ```bash
-speedctl pull dlp-rule prod-payment-data-redaction
+speedctl pull dlp prod-payment-data-redaction
 ```
 
 After pulling, you can edit the rule file locally. The file contains the DLP configuration including transform chains, filters, and extractors.
 
 ## Pushing DLP Rules
 
-Use `speedctl push dlp-rule` to upload a modified DLP rule from your local machine back to Speedscale.
+Use `speedctl push dlp` to upload a modified DLP rule from your local machine back to Speedscale.
 
 ```bash
-speedctl push dlp-rule <rule-id>
+speedctl push dlp <rule-id>
 ```
 
 ### Example
 
 ```bash
-speedctl push dlp-rule prod-payment-data-redaction
+speedctl push dlp prod-payment-data-redaction
 ```
 
 After pushing, the updated rule is available in Speedscale. Forwarders that reference the rule will automatically apply the changes; no manual refresh or redeployment is required.
 
 ## Typical Workflow
 
-1. **Pull** the rule from Speedscale: `speedctl pull dlp-rule my-dlp-rule`
-2. **Edit** the rule file locally (e.g., `~/.speedscale/data/dlp-rules/my-dlp-rule.json`)
-3. **Push** the updated rule back: `speedctl push dlp-rule my-dlp-rule`
+1. **Pull** the rule from Speedscale: `speedctl pull dlp my-dlp-rule`
+2. **Edit** the rule file locally (e.g., `~/.speedscale/data/dlp/my-dlp-rule.json`)
+3. **Push** the updated rule back: `speedctl push dlp my-dlp-rule`
 4. **Apply** the rule to forwarders via the UI or your deployment configuration
 
 ## Next Steps

--- a/docs/guides/ingress.md
+++ b/docs/guides/ingress.md
@@ -81,10 +81,10 @@ metadata:
 If the above secret is missing, one can easily be created with `speedctl` and `kubectl`:
 
 ```shell
-speedctl create certs -o .
+speedctl create certs
 kubectl create -n ingress-nginx secret ingress-nginx-admission \
-    --from-file=key=tls.key \
-    --from-file=cert=tls.crt
+    --from-file=key=$HOME/.speedscale/certs/tls.key \
+    --from-file=cert=$HOME/.speedscale/certs/tls.crt
 ```
 
 :::

--- a/docs/guides/replay/mocks/modify-mocks.md
+++ b/docs/guides/replay/mocks/modify-mocks.md
@@ -23,7 +23,7 @@ speedctl pull snapshot {SNAPSHOT_ID}
 You’ll want to open the raw file for your snapshot in your favorite editor like VSCode. If you have an editor configured in your terminal you can do this by running:
 
 ```bash
-speedctl edit {SNAPSHOT_ID}
+speedctl edit snapshot raw {SNAPSHOT_ID}
 ```
 
 If you don't have an editor configured then you can open the file directly with VSCode (or another text editor) by inserting SNAPSHOT_ID into the folowing command:

--- a/docs/guides/reports/status.md
+++ b/docs/guides/reports/status.md
@@ -150,10 +150,10 @@ The replay was manually canceled by a user before completion.
 
 ```bash
 # Wait for report completion and get exit code based on status
-speedctl wait <report-id>
+speedctl wait report <report-id>
 
-# List reports with status filtering
-speedctl report list --status "Passed"
+# List recent reports for a specific service
+speedctl get reports --service my-service
 ```
 
 ### Using the UI

--- a/docs/guides/websocket.md
+++ b/docs/guides/websocket.md
@@ -69,12 +69,12 @@ This means your service's WebSocket dependencies are mocked just like HTTP depen
 For local development, proxymock can mock WebSocket endpoints:
 
 ```bash
-proxymock mock start \
-  --in-dir ./captured-traffic \
-  --port 8080
+proxymock mock \
+  --in ./captured-traffic \
+  --proxy-out-port 8080
 ```
 
-Your service connects to the mock server on port 8080. When it upgrades to a WebSocket connection, proxymock responds with the captured message sequence.
+Configure your service to use proxymock as its HTTP(S) proxy on port 8080. When it upgrades to a WebSocket connection, proxymock responds with the captured message sequence.
 
 ## Supported Frame Types
 

--- a/docs/proxymock/getting-started/faq.md
+++ b/docs/proxymock/getting-started/faq.md
@@ -25,7 +25,7 @@ Most definitely, but for that you need to consider an Enterprise subscription. B
 
 ## What happens if the mock server doesn't have a response for a request?
 
-**proxymock** defaults to **passthrough** mode which means it will reach out to the real system and return the response. The request and response will then be added to the `./proxymock` directory. You can modify the response if you like using the RRPair editor and then save. Run `proxymock analyze` to process mocks so they will be used when **proxymock** is run. You thought we were going to tell you to write a script, right? We like you too much for that. To learn more about signature matching, see the [signatures](../how-it-works/signature.md) section.
+**proxymock** defaults to **passthrough** mode which means it will reach out to the real system and return the response. The new request and response data will be written to proxymock's mock results directory (by default `proxymock/results/mocked-<timestamp>`). If you want to reuse those responses on the next run, inspect or edit that output and then pass it back to `proxymock mock` with `--in` (or merge the files into your existing input directory). You thought we were going to tell you to write a script, right? We like you too much for that. To learn more about signature matching, see the [signatures](../how-it-works/signature.md) section.
 
 ## What language support is there?
 

--- a/docs/proxymock/how-it-works/lifecycle.md
+++ b/docs/proxymock/how-it-works/lifecycle.md
@@ -7,8 +7,9 @@ sidebar_position: 2
 
 Using **proxymock** starts with recording
 [traffic](/reference/glossary.md#traffic).  See the `proxymock record` command.
-Recorded traffic is stored in files in the `proxymock` directory, relative to
-wherever proxymock was run.
+Recorded traffic is stored in files under a timestamped directory such as
+`proxymock/recorded-<timestamp>`, relative to wherever proxymock was run, unless
+`--out` is specified.
 
 Traffic going to (tests), and coming from (mocks), your app can be recorded.
 The recorded traffic that went to your app can be replayed with `proxymock
@@ -16,7 +17,9 @@ replay`.  The recorded traffic that went from your app to external resources can
 be used to create a [mock server](/reference/glossary.md#mock-server) with `proxymock mock`.
 
 When running `proxymock replay` or `proxymock mock` new requests are also
-recorded to the `proxymock` directory, unless disabled with a CLI flag.
+recorded by default to `proxymock/results/replayed-<timestamp>` or
+`proxymock/results/mocked-<timestamp>`, unless disabled or overridden with CLI
+flags.
 
 ## Mock Server Lifecycle
 


### PR DESCRIPTION
## What Changed and Why
This updates stale `speedctl` and `proxymock` CLI examples in `speedscale/docs` so they match current help/source from `speedscale/master`. It fixes the cert-generation examples, DLP pull/push syntax, snapshot editing, report commands, ingress cert instructions, `proxymock files compare` guidance, websocket mock usage, and the current proxymock output-directory behavior in FAQ/lifecycle docs.

## How I Verified
- Ran `/Users/rachel/.openclaw/workspace-speedy/thoughts/scripts/verify-spd-11588-cli-doc-examples.sh`
- Ran `npm --prefix /Users/rachel/code/docs/SPD-11588-cli-example-audit run build`
- Got a clean speedy-critic approval after the final fixes

## Ticket
- SPD-11588
