### PR TITLE
Clarify GKE Autopilot and sidecar proxy docs

### DIFF
--- a/docs/getting-started/installation/sidecar/_language_specific_tls_config.mdx
+++ b/docs/getting-started/installation/sidecar/_language_specific_tls_config.mdx
@@ -77,6 +77,10 @@ When running in-cluster, these flags are also surfaced as an environment variabl
 These truststore settings do not configure outbound proxy routing. If you are using `forward` or `dual`
 proxy mode, you still need the Java proxy flags described on the [Java reference](/reference/languages/java.md).
 
+If you need the operator to write a complete custom `JAVA_TOOL_OPTIONS` string instead of the default JKS
+flags, use `sidecar.speedscale.com/tls-java-tool-options-value`. If both Java TLS annotations are set, the
+custom value takes precedence.
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment

--- a/docs/getting-started/installation/sidecar/_language_specific_tls_config.mdx
+++ b/docs/getting-started/installation/sidecar/_language_specific_tls_config.mdx
@@ -74,6 +74,9 @@ about this setting here.
 
 When running in-cluster, these flags are also surfaced as an environment variable `SPEEDSCALE_JAVA_OPTS` if you need to merge with your own existing sets of Java flags.
 
+These truststore settings do not configure outbound proxy routing. If you are using `forward` or `dual`
+proxy mode, you still need the Java proxy flags described on the [Java reference](/reference/languages/java.md).
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -135,4 +138,3 @@ Python applications (including the popular requests library and many others) wil
 
 </TabItem>
 </Tabs>
-

--- a/docs/getting-started/installation/sidecar/proxy-modes.md
+++ b/docs/getting-started/installation/sidecar/proxy-modes.md
@@ -16,6 +16,12 @@ In these instances, the Speedscale sidecar must be run as an inline proxy that e
 proxy rather than transparently intercepting them. There are two halves to this inline proxy operation: a
 reverse proxy for handling inbound traffic, and a forward proxy for handling outbound traffic.
 
+:::warning
+`forward` and `dual` modes do not automatically reconfigure your application. Sidecar injection can succeed
+while outbound capture stays empty if the workload runtime does not send traffic to the forward proxy on
+`127.0.0.1:4140` or your configured `proxy-out-port`.
+:::
+
 :::tip Remember
 When using the annotation examples below, be sure to _add_ them to any existing annotations on your workload.
 :::
@@ -31,6 +37,15 @@ the sidecar should operate as: reverse, forward, or dual (both reverse and forwa
 
 Sidecar reverse and forward proxies support the following proxy protocols: `http`, `socks4`, and `socks5`.
 Authentication is not required.
+
+## Operator And Runtime Responsibilities
+
+Switching away from `transparent` mode introduces two separate pieces of configuration:
+
+- `reverse`: the operator configures the sidecar to accept inbound traffic and forward it to your app.
+- `forward`: your workload runtime must explicitly use the sidecar as its outbound proxy.
+- `dual`: both of the above apply. Inbound traffic reaches the sidecar, and outbound traffic must still be
+  configured in the application runtime.
 
 Reverse proxies can be configured to require no specific proxy protocol, but instead operate as a simple TCP
 proxy. When operating in this mode, the sidecar treats incoming requests are treated as opaque TCP connections
@@ -68,6 +83,26 @@ For outbound forward proxy requests, the sidecar will listen on port `4140`, whi
 an annotation:
 
 - `sidecar.speedscale.com/proxy-out-port: "11000"`
+
+## Runtime Configuration For Outbound Traffic
+
+For `forward` and `dual` modes, the workload must be configured to use the sidecar's forward proxy.
+
+Common patterns:
+
+- `HTTP_PROXY=http://127.0.0.1:4140`
+- `HTTPS_PROXY=http://127.0.0.1:4140`
+- `JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=4140 -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=4140`
+
+If you changed `sidecar.speedscale.com/proxy-out-port`, use that port in the runtime configuration too.
+
+Language-specific notes:
+
+- Java: [Java reference](/reference/languages/java.md)
+- Node.js: [Node.js reference](/reference/languages/nodejs.md)
+- Python: [Python reference](/reference/languages/python.md)
+- Go: [Go reference](/reference/languages/golang.md)
+- .NET: [.NET reference](/reference/languages/dotnet.md)
 
 ### Examples
 
@@ -111,6 +146,20 @@ annotations:
   sidecar.speedscale.com/proxy-port: "8080"
   sidecar.speedscale.com/proxy-in-port: "10000"
   sidecar.speedscale.com/proxy-out-port: "10001"
+```
+
+After applying the workload annotations above, the application still needs matching runtime settings. For
+example, if the forward proxy remains on `4140`, many workloads will need either:
+
+```bash
+export HTTP_PROXY=http://127.0.0.1:4140
+export HTTPS_PROXY=http://127.0.0.1:4140
+```
+
+or for Java:
+
+```bash
+export JAVA_TOOL_OPTIONS="-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=4140 -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=4140"
 ```
 
 <ConfiguringProxy />

--- a/docs/getting-started/installation/sidecar/tls.md
+++ b/docs/getting-started/installation/sidecar/tls.md
@@ -106,8 +106,10 @@ runtime to use the sidecar's forward proxy, and proxy configuration alone does n
 Speedscale CA when `tls-out` is enabled.
 :::
 
-For Java specifically, `sidecar.speedscale.com/tls-java-tool-options: "true"` handles truststore settings
-only. It does not add `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, or `-Dhttps.proxyPort`.
+For Java specifically, `sidecar.speedscale.com/tls-java-tool-options: "true"` only adds the default
+truststore settings. It does not add `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, or
+`-Dhttps.proxyPort`. If you need the operator to write a fully merged `JAVA_TOOL_OPTIONS` value, use
+`sidecar.speedscale.com/tls-java-tool-options-value`; if both annotations are present, the custom value wins.
 See the [Java reference](/reference/languages/java.md) for the combined in-cluster example.
 
 <LanguageSpecificTLSConfiguration />

--- a/docs/getting-started/installation/sidecar/tls.md
+++ b/docs/getting-started/installation/sidecar/tls.md
@@ -46,6 +46,8 @@ To unwrap outbound TLS calls there are multiple steps required:
 
 - Configure the sidecar to enable outbound TLS interception
 - Configure your application to trust the new TLS Certificates
+- If you are using `forward` or `dual` proxy mode, separately configure the application runtime to route
+  outbound traffic through the sidecar
 
 When your deployment is injected, the sidecar will have an extra environment variable `TLS_OUT_UNWRAP=true`
 and a volume mount to access the files from the `speedscale-certs` secret. The operator will automatically
@@ -57,6 +59,9 @@ annotations:
   sidecar.speedscale.com/inject: "true"
   sidecar.speedscale.com/tls-out: "true"
 ```
+
+Enabling `tls-out` does not change how the application routes outbound traffic. It only enables TLS
+interception after traffic is already flowing through the sidecar.
 
 ## Mutual Authentication for Outbound Calls
 
@@ -94,6 +99,16 @@ calls to be handled automatically.
 :::danger
 Configuring TLS trust is, in most cases, language specific. Every runtime language has different characteristics and if you do not configure this correctly you will get TLS/SSL errors. Always configure this in a controlled environment first.
 :::
+
+:::note
+TLS trust and outbound proxy routing are separate requirements. Trusting the Speedscale CA does not tell the
+runtime to use the sidecar's forward proxy, and proxy configuration alone does not make the runtime trust the
+Speedscale CA when `tls-out` is enabled.
+:::
+
+For Java specifically, `sidecar.speedscale.com/tls-java-tool-options: "true"` handles truststore settings
+only. It does not add `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, or `-Dhttps.proxyPort`.
+See the [Java reference](/reference/languages/java.md) for the combined in-cluster example.
 
 <LanguageSpecificTLSConfiguration />
 

--- a/docs/guides/integrations/gcp.md
+++ b/docs/guides/integrations/gcp.md
@@ -21,6 +21,19 @@ Because of this, the Speedscale sidecar is unable to make the necessary networki
 as a transparent proxy. Applications running in GKE Autopilot must configure the [proxy mode](/getting-started/installation/sidecar/proxy-modes.md)
 of the sidecar to operate as a standard forward and reverse proxy (i.e. the "dual" proxy operation mode).
 
+`transparent` proxy mode is not supported in GKE Autopilot.
+
+Autopilot also blocks the sidecar's smart reverse DNS behavior because it requires the `NET_ADMIN`
+capability. When installing the Speedscale operator with Helm, set
+`disableSidecarSmartReverseDNS: true` in your operator values. See the [Helm reference](/reference/helm.md)
+for details.
+
+`dual` mode changes how the sidecar operates, but it does not reconfigure your application runtime to send
+outbound requests to the sidecar's forward proxy. Your workload must still use runtime-specific proxy
+settings such as `HTTP_PROXY` and `HTTPS_PROXY` or Java `JAVA_TOOL_OPTIONS` flags. See
+[Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md), [TLS Support](/getting-started/installation/sidecar/tls.md),
+and the [Java reference](/reference/languages/java.md) for the combined in-cluster Java example.
+
 In addition to this limitation, Autopilot also enforces rules for container resource requests and limits.
 Without any resource requests or limits set for a container, Autopilot will apply a default value. However,
 for those that do specify resources, the value for both the request and the limit must be the same. Without
@@ -28,10 +41,12 @@ additional configuration, the Speedscale operator will configure injected sideca
 settings for CPU and memory in order to ensure that clusters utilitizing horizontal pod autoscaling work as
 designed. Ephemeral storage requests/limits must also be specified. Additional workload annotations are necessary to ensure that these values are equivalent.
 
-A complete example of the settings necessary to inject the Speedscale sidecar into an application workload
-that listens for connections on port 8080 may look like the following in the helm `values.yaml`:
+A complete example of the operator-level settings necessary for GKE Autopilot may look like the following in
+the Helm `values.yaml`:
 
 ```
+disableSidecarSmartReverseDNS: true
+
 sidecar:
   resources:
     limits:
@@ -44,7 +59,7 @@ sidecar:
       ephemeral-storage: 100Mi
 ```
 
-or via annotations:
+Then configure the workload for inline proxy mode with annotations such as:
 
 ```
 sidecar.speedscale.com/inject: "true"
@@ -58,3 +73,16 @@ sidecar.speedscale.com/memory-limit: 1Gi
 sidecar.speedscale.com/ephemeral-storage-request: 100Mi
 sidecar.speedscale.com/ephemeral-storage-limit: 100Mi
 ```
+
+### What You Must Still Configure In The App
+
+After the sidecar is injected, the application runtime must still send outbound traffic to the sidecar's
+forward proxy on `127.0.0.1:4140` unless you changed `proxy-out-port`.
+
+- Java: add `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, and `-Dhttps.proxyPort` in
+  `JAVA_TOOL_OPTIONS`. If you also enable `tls-out`, add the truststore flags documented on the
+  [Java reference](/reference/languages/java.md).
+- Languages that honor proxy environment variables: set `HTTP_PROXY` and `HTTPS_PROXY` to
+  `http://127.0.0.1:4140`.
+- Languages or client libraries with custom proxy behavior: configure the library directly so outbound
+  traffic actually uses the sidecar.

--- a/docs/reference/languages/dotnet.md
+++ b/docs/reference/languages/dotnet.md
@@ -13,6 +13,24 @@ import ProxymockLanguageWorkflow from '@site/src/components/ProxymockLanguageWor
 - Support matrix: [Technology Support](/reference/technology-support)
 - Shared Proxymock proxy reference: [Language Configuration](/proxymock/getting-started/language-reference)
 
+## Kubernetes Sidecar
+
+When .NET runs with the Speedscale sidecar in `forward` or `dual` mode, configure outbound traffic to use
+the sidecar's forward proxy on `127.0.0.1:4140` unless you changed `proxy-out-port`.
+
+Typical settings:
+
+```bash
+export HTTP_PROXY=http://127.0.0.1:4140
+export HTTPS_PROXY=http://127.0.0.1:4140
+```
+
+If `tls-out` is enabled, trust the Speedscale CA separately, commonly with `SSL_CERT_FILE` on Linux-based
+.NET containers.
+
+See [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md) and
+[TLS Support](/getting-started/installation/sidecar/tls.md) for the shared sidecar behavior.
+
 ## Demo App
 
 - Public demo: [speedscale/demo](https://github.com/speedscale/demo) (`csharp` directory)

--- a/docs/reference/languages/golang.md
+++ b/docs/reference/languages/golang.md
@@ -13,6 +13,20 @@ Go is fully supported by Speedscale. Use this page for Go-specific proxy setting
 - Support matrix: [Technology Support](/reference/technology-support)
 - Shared Proxymock proxy reference: [Language Configuration](/proxymock/getting-started/language-reference)
 
+## Kubernetes Sidecar
+
+When Go runs with the Speedscale sidecar in `forward` or `dual` mode, the Go runtime must still send
+outbound traffic to the sidecar. Set `HTTP_PROXY` and `HTTPS_PROXY` to `http://127.0.0.1:4140` unless you
+changed `proxy-out-port`.
+
+If `tls-out` is enabled, trust and routing are separate concerns:
+
+- routing: `HTTP_PROXY` and `HTTPS_PROXY`
+- TLS trust: `SSL_CERT_FILE` or the language-specific trust mechanism in your image
+
+See [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md) and
+[TLS Support](/getting-started/installation/sidecar/tls.md) for the shared sidecar behavior.
+
 ## Demo App
 
 - Public demo: [speedscale/outerspace-go](https://github.com/speedscale/outerspace-go)

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -65,7 +65,7 @@ spec:
 This is the most explicit option because it keeps the outbound proxy settings and truststore settings in one
 place.
 
-### Using `tls-java-tool-options`
+### Default Truststore Helper
 
 If you enable the Java TLS helper annotation:
 
@@ -90,6 +90,48 @@ env:
 When available in your image, `SPEEDSCALE_JAVA_OPTS` exposes the truststore flags separately so they can be
 merged with your existing startup command. Keep any existing application-specific JVM options when adding the
 Speedscale flags.
+
+### Recommended: `tls-java-tool-options-value`
+
+If you want the operator to set the full `JAVA_TOOL_OPTIONS` value for you, use
+`sidecar.speedscale.com/tls-java-tool-options-value`. This is the cleanest option when you need one merged
+string that includes:
+
+- outbound proxy routing flags
+- Java truststore flags for `tls-out`
+- your existing application-specific JVM flags
+
+If both `sidecar.speedscale.com/tls-java-tool-options` and
+`sidecar.speedscale.com/tls-java-tool-options-value` are set, the custom value takes precedence.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-boot-app
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.speedscale.com/inject: "true"
+        sidecar.speedscale.com/proxy-type: "dual"
+        sidecar.speedscale.com/proxy-protocol: "tcp:http"
+        sidecar.speedscale.com/proxy-port: "8080"
+        sidecar.speedscale.com/tls-out: "true"
+        sidecar.speedscale.com/tls-java-tool-options-value: >-
+          -Dhttp.proxyHost=127.0.0.1
+          -Dhttp.proxyPort=4140
+          -Dhttps.proxyHost=127.0.0.1
+          -Dhttps.proxyPort=4140
+          -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
+          -Djavax.net.ssl.trustStore=/etc/ssl/speedscale/jks/cacerts.jks
+          -Djavax.net.ssl.trustStorePassword=changeit
+          -javaagent:/opt/agent.jar
+          -Xmx512m
+```
+
+Because this annotation overrides the value completely, include every Java flag you still need. Do not assume
+the default truststore flags will be appended automatically.
 
 ## Demo App
 

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -17,21 +17,19 @@ Java is fully supported by Speedscale. Use this page for Java-specific proxy set
 
 ## Choose Your Java Capture Mode
 
-There are four common Java setups, and they do not use the same annotations or runtime configuration:
+Quick links:
 
-1. [**eBPF / Java agent**](#ebpf-java-agent): best Kubernetes option when eBPF capture is available.
-2. [**Transparent sidecar**](#transparent-sidecar): default sidecar mode.
-3. [**Dual sidecar**](#dual-sidecar): exception path for environments where transparent mode is unavailable,
-   such as [GKE Autopilot](/guides/integrations/gcp.md).
-4. [**Proxymock**](#proxymock): local development and CI workflow.
+- [eBPF / Java agent](#ebpf-java-agent)
+- [Transparent sidecar](#transparent-sidecar)
+- [Dual sidecar](#dual-sidecar)
+- [Proxymock](#proxymock)
 
 ## eBPF / Java Agent {#ebpf-java-agent}
 
-Use this when your cluster supports [eBPF traffic collection](/reference/ebpf-traffic-collection) and you
-want the least application-specific configuration in Kubernetes.
+Use this when your cluster supports [eBPF traffic collection](/reference/ebpf-traffic-collection). For Java,
+Speedscale uses a Java agent for JVM traffic capture.
 
-Java is special here: Speedscale uses a Java agent for JVM traffic capture instead of relying only on generic
-TLS probes. The workload annotations are:
+Workload annotations:
 
 ```yaml
 capture.speedscale.com/enabled: "true"

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -28,74 +28,13 @@ If `tls-out` is enabled, Java must do two separate things:
 - route outbound traffic through the sidecar with JVM proxy flags
 - trust the Speedscale CA with the mounted JKS truststore
 
-### Manual In-Cluster JVM Flags
-
-If your container already defines `JAVA_TOOL_OPTIONS`, merge the Speedscale settings into that existing
-value. Kubernetes environment variables replace existing values; they do not append automatically.
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: spring-boot-app
-spec:
-  template:
-    metadata:
-      annotations:
-        sidecar.speedscale.com/inject: "true"
-        sidecar.speedscale.com/proxy-type: "dual"
-        sidecar.speedscale.com/proxy-protocol: "tcp:http"
-        sidecar.speedscale.com/proxy-port: "8080"
-        sidecar.speedscale.com/tls-out: "true"
-    spec:
-      containers:
-      - name: app
-        env:
-        - name: JAVA_TOOL_OPTIONS
-          value: >-
-            -Dhttp.proxyHost=127.0.0.1
-            -Dhttp.proxyPort=4140
-            -Dhttps.proxyHost=127.0.0.1
-            -Dhttps.proxyPort=4140
-            -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
-            -Djavax.net.ssl.trustStore=/etc/ssl/speedscale/jks/cacerts.jks
-            -Djavax.net.ssl.trustStorePassword=changeit
-```
-
-This is the most explicit option because it keeps the outbound proxy settings and truststore settings in one
-place.
-
-### Default Truststore Helper
-
-If you enable the Java TLS helper annotation:
-
-```yaml
-sidecar.speedscale.com/tls-out: "true"
-sidecar.speedscale.com/tls-java-tool-options: "true"
-```
-
-the operator handles the truststore flags, but you still must provide the proxy flags yourself, for example:
-
-```yaml
-env:
-- name: JAVA_TOOL_OPTIONS
-  value: >-
-    -Dhttp.proxyHost=127.0.0.1
-    -Dhttp.proxyPort=4140
-    -Dhttps.proxyHost=127.0.0.1
-    -Dhttps.proxyPort=4140
-    -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
-```
-
-When available in your image, `SPEEDSCALE_JAVA_OPTS` exposes the truststore flags separately so they can be
-merged with your existing startup command. Keep any existing application-specific JVM options when adding the
-Speedscale flags.
-
 ### Recommended: `tls-java-tool-options-value`
 
-If you want the operator to set the full `JAVA_TOOL_OPTIONS` value for you, use
-`sidecar.speedscale.com/tls-java-tool-options-value`. This is the cleanest option when you need one merged
-string that includes:
+Use `sidecar.speedscale.com/tls-java-tool-options-value` as the primary Kubernetes path. This lets the
+operator write the full merged `JAVA_TOOL_OPTIONS` value instead of making you patch the container `env`
+block manually.
+
+This is the cleanest option when you need one merged string that includes:
 
 - outbound proxy routing flags
 - Java truststore flags for `tls-out`
@@ -132,6 +71,56 @@ spec:
 
 Because this annotation overrides the value completely, include every Java flag you still need. Do not assume
 the default truststore flags will be appended automatically.
+
+### Default Truststore Helper
+
+If you enable the Java TLS helper annotation:
+
+```yaml
+sidecar.speedscale.com/tls-out: "true"
+sidecar.speedscale.com/tls-java-tool-options: "true"
+```
+
+the operator handles the truststore flags, but you still must provide the proxy flags yourself, for example:
+
+```yaml
+env:
+- name: JAVA_TOOL_OPTIONS
+  value: >-
+    -Dhttp.proxyHost=127.0.0.1
+    -Dhttp.proxyPort=4140
+    -Dhttps.proxyHost=127.0.0.1
+    -Dhttps.proxyPort=4140
+    -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
+```
+
+When available in your image, `SPEEDSCALE_JAVA_OPTS` exposes the truststore flags separately so they can be
+merged with your existing startup command. Keep any existing application-specific JVM options when adding the
+Speedscale flags.
+
+### Manual `env` Fallback
+
+If you cannot use the annotation-driven path, you can still set `JAVA_TOOL_OPTIONS` directly in the workload
+spec. If your container already defines `JAVA_TOOL_OPTIONS`, merge the Speedscale settings into that existing
+value. Kubernetes environment variables replace existing values; they do not append automatically.
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        env:
+        - name: JAVA_TOOL_OPTIONS
+          value: >-
+            -Dhttp.proxyHost=127.0.0.1
+            -Dhttp.proxyPort=4140
+            -Dhttps.proxyHost=127.0.0.1
+            -Dhttps.proxyPort=4140
+            -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
+            -Djavax.net.ssl.trustStore=/etc/ssl/speedscale/jks/cacerts.jks
+            -Djavax.net.ssl.trustStorePassword=changeit
+```
 
 ## Demo App
 

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -15,112 +15,124 @@ Java is fully supported by Speedscale. Use this page for Java-specific proxy set
 - Shared sidecar docs: [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md) and [TLS Support](/getting-started/installation/sidecar/tls.md)
 - GKE Autopilot guidance: [GCP](/guides/integrations/gcp.md)
 
-## Kubernetes Sidecar {#kubernetes-sidecar}
+## Choose Your Java Capture Mode
 
-Use this section when Java is running in Kubernetes with the Speedscale sidecar rather than local Proxymock.
+There are four common Java setups, and they do not use the same annotations or runtime configuration:
 
-For outbound HTTP(S) capture, configure the workload with `proxy-type: "forward"` or `proxy-type: "dual"`
-and use `proxy-protocol: "http"` or `proxy-protocol: "tcp:http"`. The sidecar listens for outbound traffic
-on `127.0.0.1:4140` by default.
+1. **eBPF / Java agent**: best Kubernetes option when eBPF capture is available. No sidecar proxy settings, no
+   `tls-out`, and no Java proxy host configuration.
+2. **Transparent sidecar**: default sidecar mode. No Java proxy host configuration. Add `tls-out` and the Java
+   TLS helper only if you need outbound TLS decryption.
+3. **Dual sidecar**: exception path for environments where transparent mode is unavailable, such as
+   [GKE Autopilot](/guides/integrations/gcp.md). Requires both Java proxy flags and Java truststore settings.
+4. **Proxymock**: local development and CI workflow. Common for Java, but it does not use Kubernetes
+   annotations.
 
-If `tls-out` is enabled, Java must do two separate things:
+## eBPF / Java Agent
 
-- route outbound traffic through the sidecar with JVM proxy flags
-- trust the Speedscale CA with the mounted JKS truststore
+Use this when your cluster supports [eBPF traffic collection](/reference/ebpf-traffic-collection) and you
+want the least application-specific configuration in Kubernetes.
 
-### Recommended: `tls-java-tool-options-value`
-
-Use `sidecar.speedscale.com/tls-java-tool-options-value` as the primary Kubernetes path. This lets the
-operator write the full merged `JAVA_TOOL_OPTIONS` value instead of making you patch the container `env`
-block manually.
-
-This is the cleanest option when you need one merged string that includes:
-
-- outbound proxy routing flags
-- Java truststore flags for `tls-out`
-- your existing application-specific JVM flags
-
-If both `sidecar.speedscale.com/tls-java-tool-options` and
-`sidecar.speedscale.com/tls-java-tool-options-value` are set, the custom value takes precedence.
+Java is special here: Speedscale uses a Java agent for JVM traffic capture instead of relying only on generic
+TLS probes. The workload annotations are:
 
 ```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: spring-boot-app
-spec:
-  template:
-    metadata:
-      annotations:
-        sidecar.speedscale.com/inject: "true"
-        sidecar.speedscale.com/proxy-type: "dual"
-        sidecar.speedscale.com/proxy-protocol: "tcp:http"
-        sidecar.speedscale.com/proxy-port: "8080"
-        sidecar.speedscale.com/tls-out: "true"
-        sidecar.speedscale.com/tls-java-tool-options-value: >-
-          -Dhttp.proxyHost=127.0.0.1
-          -Dhttp.proxyPort=4140
-          -Dhttps.proxyHost=127.0.0.1
-          -Dhttps.proxyPort=4140
-          -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
-          -Djavax.net.ssl.trustStore=/etc/ssl/speedscale/jks/cacerts.jks
-          -Djavax.net.ssl.trustStorePassword=changeit
-          -javaagent:/opt/agent.jar
-          -Xmx512m
+capture.speedscale.com/enabled: "true"
+capture.speedscale.com/java-agent: "true"
 ```
 
-Because this annotation overrides the value completely, include every Java flag you still need. Do not assume
-the default truststore flags will be appended automatically.
+What this means for Java:
 
-### Default Truststore Helper
+- no sidecar injection
+- no `sidecar.speedscale.com/tls-out`
+- no `sidecar.speedscale.com/tls-java-tool-options`
+- no `-Dhttp.proxyHost` or `-Dhttps.proxyHost`
 
-If you enable the Java TLS helper annotation:
+:::warning
+`capture.speedscale.com/java-agent: "true"` is mutually exclusive with
+`sidecar.speedscale.com/inject: "true"`. Do not combine Java-agent capture and sidecar injection on the same
+workload.
+:::
+
+## Transparent Sidecar
+
+Transparent proxy is the default sidecar mode and should be the primary sidecar path for Java when your
+environment allows it.
+
+For plain HTTP capture or non-decrypted TLS passthrough, sidecar injection is enough:
 
 ```yaml
+sidecar.speedscale.com/inject: "true"
+```
+
+If you need outbound TLS decryption, add:
+
+```yaml
+sidecar.speedscale.com/inject: "true"
 sidecar.speedscale.com/tls-out: "true"
 sidecar.speedscale.com/tls-java-tool-options: "true"
 ```
 
-the operator handles the truststore flags, but you still must provide the proxy flags yourself, for example:
+In transparent mode, Java does **not** need `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, or
+`-Dhttps.proxyPort`. The sidecar handles routing transparently.
+
+Use `sidecar.speedscale.com/tls-java-tool-options-value` only if you need to override the default truststore
+flags with a custom `JAVA_TOOL_OPTIONS` string, for example to preserve existing JVM settings:
 
 ```yaml
-env:
-- name: JAVA_TOOL_OPTIONS
-  value: >-
-    -Dhttp.proxyHost=127.0.0.1
-    -Dhttp.proxyPort=4140
-    -Dhttps.proxyHost=127.0.0.1
-    -Dhttps.proxyPort=4140
-    -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
+sidecar.speedscale.com/inject: "true"
+sidecar.speedscale.com/tls-out: "true"
+sidecar.speedscale.com/tls-java-tool-options-value: >-
+  -Djavax.net.ssl.trustStore=/etc/ssl/speedscale/jks/cacerts.jks
+  -Djavax.net.ssl.trustStorePassword=changeit
+  -Xmx512m
+  -Dspring.profiles.active=prod
 ```
 
-When available in your image, `SPEEDSCALE_JAVA_OPTS` exposes the truststore flags separately so they can be
-merged with your existing startup command. Keep any existing application-specific JVM options when adding the
-Speedscale flags.
+If both `sidecar.speedscale.com/tls-java-tool-options` and
+`sidecar.speedscale.com/tls-java-tool-options-value` are set, the custom value takes precedence.
 
-### Manual `env` Fallback
+## Dual Sidecar
 
-If you cannot use the annotation-driven path, you can still set `JAVA_TOOL_OPTIONS` directly in the workload
-spec. If your container already defines `JAVA_TOOL_OPTIONS`, merge the Speedscale settings into that existing
-value. Kubernetes environment variables replace existing values; they do not append automatically.
+Use dual sidecar mode only when transparent proxy is unavailable. This is not the default Java sidecar path.
+
+Common examples:
+
+- GKE Autopilot
+- platforms that block the networking changes required for transparent proxy
+- workloads with other environment-specific restrictions called out in [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md)
+
+In dual mode, Java must do two separate things:
+
+- route outbound traffic through the sidecar forward proxy
+- trust the Speedscale CA when `tls-out` is enabled
+
+This is the annotation-driven example for Java in dual mode:
 
 ```yaml
-spec:
-  template:
-    spec:
-      containers:
-      - name: app
-        env:
-        - name: JAVA_TOOL_OPTIONS
-          value: >-
-            -Dhttp.proxyHost=127.0.0.1
-            -Dhttp.proxyPort=4140
-            -Dhttps.proxyHost=127.0.0.1
-            -Dhttps.proxyPort=4140
-            -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
-            -Djavax.net.ssl.trustStore=/etc/ssl/speedscale/jks/cacerts.jks
-            -Djavax.net.ssl.trustStorePassword=changeit
+sidecar.speedscale.com/inject: "true"
+sidecar.speedscale.com/proxy-type: "dual"
+sidecar.speedscale.com/proxy-protocol: "tcp:http"
+sidecar.speedscale.com/proxy-port: "8080"
+sidecar.speedscale.com/tls-out: "true"
+sidecar.speedscale.com/tls-java-tool-options-value: >-
+  -Dhttp.proxyHost=127.0.0.1
+  -Dhttp.proxyPort=4140
+  -Dhttps.proxyHost=127.0.0.1
+  -Dhttps.proxyPort=4140
+  -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
+  -Djavax.net.ssl.trustStore=/etc/ssl/speedscale/jks/cacerts.jks
+  -Djavax.net.ssl.trustStorePassword=changeit
 ```
+
+Why `tls-java-tool-options-value` is useful here:
+
+- dual mode needs proxy flags that `tls-java-tool-options: "true"` does not add
+- the annotation lets the operator write one merged `JAVA_TOOL_OPTIONS` value
+- you avoid manually patching the container `env` block in the workload spec
+
+If you cannot use the annotation-driven path, you can still set `JAVA_TOOL_OPTIONS` directly in the
+container `env`, but that should be treated as a fallback.
 
 ## Demo App
 
@@ -132,6 +144,9 @@ spec:
 This is the current public Java demo used for local Proxymock examples.
 
 ## Proxymock {#proxymock}
+
+Use this for local development and CI. Conceptually this is similar to dual proxy mode because Java sends
+traffic through a forward proxy and trusts the proxymock CA, but it does not use Kubernetes annotations.
 
 <ProxymockLanguageWorkflow
   intro="Use this path for the fastest Java first success on a developer workstation."
@@ -186,5 +201,13 @@ proxymock replay --in ./proxymock/recorded --test-against http://localhost:8080`
 
 Java typically needs an explicit truststore when TLS interception is involved. See the shared [Language Configuration](/proxymock/getting-started/language-reference#tls-trust) page for the exact `proxymock certs --jks` command, JVM flags, and custom truststore workflow.
 
-For Kubernetes sidecar mode, truststore configuration alone is not enough. You also need the proxy flags
-shown in [Kubernetes Sidecar](#kubernetes-sidecar).
+How that trust is configured depends on the capture mode:
+
+- eBPF / Java agent: no sidecar TLS truststore settings are required on this page.
+- Transparent sidecar: use `sidecar.speedscale.com/tls-java-tool-options: "true"` for the default truststore
+  flags, or `sidecar.speedscale.com/tls-java-tool-options-value` if you need a custom `JAVA_TOOL_OPTIONS`
+  value.
+- Dual sidecar: truststore configuration alone is not enough. You also need the Java proxy flags shown in
+  [Dual Sidecar](#dual-sidecar).
+- Proxymock: use the local truststore flags shown in the shared
+  [Language Configuration](/proxymock/getting-started/language-reference#tls-trust) page.

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -12,6 +12,84 @@ Java is fully supported by Speedscale. Use this page for Java-specific proxy set
 
 - Support matrix: [Technology Support](/reference/technology-support)
 - Shared Proxymock proxy reference: [Language Configuration](/proxymock/getting-started/language-reference)
+- Shared sidecar docs: [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md) and [TLS Support](/getting-started/installation/sidecar/tls.md)
+- GKE Autopilot guidance: [GCP](/guides/integrations/gcp.md)
+
+## Kubernetes Sidecar {#kubernetes-sidecar}
+
+Use this section when Java is running in Kubernetes with the Speedscale sidecar rather than local Proxymock.
+
+For outbound HTTP(S) capture, configure the workload with `proxy-type: "forward"` or `proxy-type: "dual"`
+and use `proxy-protocol: "http"` or `proxy-protocol: "tcp:http"`. The sidecar listens for outbound traffic
+on `127.0.0.1:4140` by default.
+
+If `tls-out` is enabled, Java must do two separate things:
+
+- route outbound traffic through the sidecar with JVM proxy flags
+- trust the Speedscale CA with the mounted JKS truststore
+
+### Manual In-Cluster JVM Flags
+
+If your container already defines `JAVA_TOOL_OPTIONS`, merge the Speedscale settings into that existing
+value. Kubernetes environment variables replace existing values; they do not append automatically.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-boot-app
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.speedscale.com/inject: "true"
+        sidecar.speedscale.com/proxy-type: "dual"
+        sidecar.speedscale.com/proxy-protocol: "tcp:http"
+        sidecar.speedscale.com/proxy-port: "8080"
+        sidecar.speedscale.com/tls-out: "true"
+    spec:
+      containers:
+      - name: app
+        env:
+        - name: JAVA_TOOL_OPTIONS
+          value: >-
+            -Dhttp.proxyHost=127.0.0.1
+            -Dhttp.proxyPort=4140
+            -Dhttps.proxyHost=127.0.0.1
+            -Dhttps.proxyPort=4140
+            -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
+            -Djavax.net.ssl.trustStore=/etc/ssl/speedscale/jks/cacerts.jks
+            -Djavax.net.ssl.trustStorePassword=changeit
+```
+
+This is the most explicit option because it keeps the outbound proxy settings and truststore settings in one
+place.
+
+### Using `tls-java-tool-options`
+
+If you enable the Java TLS helper annotation:
+
+```yaml
+sidecar.speedscale.com/tls-out: "true"
+sidecar.speedscale.com/tls-java-tool-options: "true"
+```
+
+the operator handles the truststore flags, but you still must provide the proxy flags yourself, for example:
+
+```yaml
+env:
+- name: JAVA_TOOL_OPTIONS
+  value: >-
+    -Dhttp.proxyHost=127.0.0.1
+    -Dhttp.proxyPort=4140
+    -Dhttps.proxyHost=127.0.0.1
+    -Dhttps.proxyPort=4140
+    -Dhttp.nonProxyHosts=localhost|127.0.0.1|*.svc|*.cluster.local
+```
+
+When available in your image, `SPEEDSCALE_JAVA_OPTS` exposes the truststore flags separately so they can be
+merged with your existing startup command. Keep any existing application-specific JVM options when adding the
+Speedscale flags.
 
 ## Demo App
 
@@ -76,3 +154,6 @@ proxymock replay --in ./proxymock/recorded --test-against http://localhost:8080`
 ## TLS Trust {#tls-trust}
 
 Java typically needs an explicit truststore when TLS interception is involved. See the shared [Language Configuration](/proxymock/getting-started/language-reference#tls-trust) page for the exact `proxymock certs --jks` command, JVM flags, and custom truststore workflow.
+
+For Kubernetes sidecar mode, truststore configuration alone is not enough. You also need the proxy flags
+shown in [Kubernetes Sidecar](#kubernetes-sidecar).

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -19,16 +19,13 @@ Java is fully supported by Speedscale. Use this page for Java-specific proxy set
 
 There are four common Java setups, and they do not use the same annotations or runtime configuration:
 
-1. **eBPF / Java agent**: best Kubernetes option when eBPF capture is available. No sidecar proxy settings, no
-   `tls-out`, and no Java proxy host configuration.
-2. **Transparent sidecar**: default sidecar mode. No Java proxy host configuration. Add `tls-out` and the Java
-   TLS helper only if you need outbound TLS decryption.
-3. **Dual sidecar**: exception path for environments where transparent mode is unavailable, such as
-   [GKE Autopilot](/guides/integrations/gcp.md). Requires both Java proxy flags and Java truststore settings.
-4. **Proxymock**: local development and CI workflow. Common for Java, but it does not use Kubernetes
-   annotations.
+1. [**eBPF / Java agent**](#ebpf-java-agent): best Kubernetes option when eBPF capture is available.
+2. [**Transparent sidecar**](#transparent-sidecar): default sidecar mode.
+3. [**Dual sidecar**](#dual-sidecar): exception path for environments where transparent mode is unavailable,
+   such as [GKE Autopilot](/guides/integrations/gcp.md).
+4. [**Proxymock**](#proxymock): local development and CI workflow.
 
-## eBPF / Java Agent
+## eBPF / Java Agent {#ebpf-java-agent}
 
 Use this when your cluster supports [eBPF traffic collection](/reference/ebpf-traffic-collection) and you
 want the least application-specific configuration in Kubernetes.
@@ -41,20 +38,13 @@ capture.speedscale.com/enabled: "true"
 capture.speedscale.com/java-agent: "true"
 ```
 
-What this means for Java:
-
-- no sidecar injection
-- no `sidecar.speedscale.com/tls-out`
-- no `sidecar.speedscale.com/tls-java-tool-options`
-- no `-Dhttp.proxyHost` or `-Dhttps.proxyHost`
-
 :::warning
 `capture.speedscale.com/java-agent: "true"` is mutually exclusive with
 `sidecar.speedscale.com/inject: "true"`. Do not combine Java-agent capture and sidecar injection on the same
 workload.
 :::
 
-## Transparent Sidecar
+## Transparent Sidecar {#transparent-sidecar}
 
 Transparent proxy is the default sidecar mode and should be the primary sidecar path for Java when your
 environment allows it.
@@ -73,9 +63,6 @@ sidecar.speedscale.com/tls-out: "true"
 sidecar.speedscale.com/tls-java-tool-options: "true"
 ```
 
-In transparent mode, Java does **not** need `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, or
-`-Dhttps.proxyPort`. The sidecar handles routing transparently.
-
 Use `sidecar.speedscale.com/tls-java-tool-options-value` only if you need to override the default truststore
 flags with a custom `JAVA_TOOL_OPTIONS` string, for example to preserve existing JVM settings:
 
@@ -92,7 +79,7 @@ sidecar.speedscale.com/tls-java-tool-options-value: >-
 If both `sidecar.speedscale.com/tls-java-tool-options` and
 `sidecar.speedscale.com/tls-java-tool-options-value` are set, the custom value takes precedence.
 
-## Dual Sidecar
+## Dual Sidecar {#dual-sidecar}
 
 Use dual sidecar mode only when transparent proxy is unavailable. This is not the default Java sidecar path.
 

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -22,6 +22,7 @@ Quick links:
 - [eBPF / Java agent](#ebpf-java-agent)
 - [Transparent sidecar](#transparent-sidecar)
 - [Dual sidecar](#dual-sidecar)
+- [TLS Trust](#tls-trust)
 - [Proxymock](#proxymock)
 
 ## eBPF / Java Agent {#ebpf-java-agent}
@@ -119,7 +120,26 @@ Why `tls-java-tool-options-value` is useful here:
 If you cannot use the annotation-driven path, you can still set `JAVA_TOOL_OPTIONS` directly in the
 container `env`, but that should be treated as a fallback.
 
-## Demo App
+## TLS Trust {#tls-trust}
+
+Java typically needs an explicit truststore when TLS interception is involved. See the shared [Language Configuration](/proxymock/getting-started/language-reference#tls-trust) page for the exact `proxymock certs --jks` command, JVM flags, and custom truststore workflow.
+
+How that trust is configured depends on the capture mode:
+
+- Transparent sidecar: use `sidecar.speedscale.com/tls-java-tool-options: "true"` for the default truststore
+  flags, or `sidecar.speedscale.com/tls-java-tool-options-value` if you need a custom `JAVA_TOOL_OPTIONS`
+  value.
+- Dual sidecar: truststore configuration alone is not enough. You also need the Java proxy flags shown in
+  [Dual Sidecar](#dual-sidecar).
+- Proxymock: use the local truststore flags shown in the shared
+  [Language Configuration](/proxymock/getting-started/language-reference#tls-trust) page.
+
+## Proxymock {#proxymock}
+
+Use this for local development and CI. Conceptually this is similar to dual proxy mode because Java sends
+traffic through a forward proxy and trusts the proxymock CA, but it does not use Kubernetes annotations.
+
+### Demo App
 
 - Public demo: [speedscale/demo](https://github.com/speedscale/demo) (`java` directory)
 - Stack: Spring Boot
@@ -127,11 +147,6 @@ container `env`, but that should be treated as a fallback.
 - Traffic generator: `make client` or `make client-capture`
 
 This is the current public Java demo used for local Proxymock examples.
-
-## Proxymock {#proxymock}
-
-Use this for local development and CI. Conceptually this is similar to dual proxy mode because Java sends
-traffic through a forward proxy and trusts the proxymock CA, but it does not use Kubernetes annotations.
 
 <ProxymockLanguageWorkflow
   intro="Use this path for the fastest Java first success on a developer workstation."
@@ -181,18 +196,3 @@ proxymock replay --in ./proxymock/recorded --test-against http://localhost:8080`
     },
   ]}
 />
-
-## TLS Trust {#tls-trust}
-
-Java typically needs an explicit truststore when TLS interception is involved. See the shared [Language Configuration](/proxymock/getting-started/language-reference#tls-trust) page for the exact `proxymock certs --jks` command, JVM flags, and custom truststore workflow.
-
-How that trust is configured depends on the capture mode:
-
-- eBPF / Java agent: no sidecar TLS truststore settings are required on this page.
-- Transparent sidecar: use `sidecar.speedscale.com/tls-java-tool-options: "true"` for the default truststore
-  flags, or `sidecar.speedscale.com/tls-java-tool-options-value` if you need a custom `JAVA_TOOL_OPTIONS`
-  value.
-- Dual sidecar: truststore configuration alone is not enough. You also need the Java proxy flags shown in
-  [Dual Sidecar](#dual-sidecar).
-- Proxymock: use the local truststore flags shown in the shared
-  [Language Configuration](/proxymock/getting-started/language-reference#tls-trust) page.

--- a/docs/reference/languages/nodejs.md
+++ b/docs/reference/languages/nodejs.md
@@ -13,6 +13,25 @@ Node.js is fully supported by Speedscale, but proxy behavior depends on the HTTP
 - Support matrix: [Technology Support](/reference/technology-support)
 - Shared Proxymock proxy reference: [Language Configuration](/proxymock/getting-started/language-reference)
 
+## Kubernetes Sidecar
+
+When Node.js runs with the Speedscale sidecar in `forward` or `dual` mode, sidecar injection alone is not
+enough for outbound capture. The Node runtime or client library must still use the sidecar's forward proxy on
+`127.0.0.1:4140`.
+
+For many apps this starts with:
+
+```bash
+export HTTP_PROXY=http://127.0.0.1:4140
+export HTTPS_PROXY=http://127.0.0.1:4140
+```
+
+Some Node.js HTTP clients ignore those variables unless you also configure an agent or library-specific proxy
+setting. If `tls-out` is enabled, also trust the Speedscale CA with `NODE_EXTRA_CA_CERTS`.
+
+See [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md) and
+[TLS Support](/getting-started/installation/sidecar/tls.md) for the shared sidecar behavior.
+
 ## Demo App
 
 - Public demo: [speedscale/demo](https://github.com/speedscale/demo) (`node` directory)

--- a/docs/reference/languages/python.md
+++ b/docs/reference/languages/python.md
@@ -13,6 +13,24 @@ Python is fully supported by Speedscale. Use this page for Python-specific proxy
 - Support matrix: [Technology Support](/reference/technology-support)
 - Shared Proxymock proxy reference: [Language Configuration](/proxymock/getting-started/language-reference)
 
+## Kubernetes Sidecar
+
+When Python runs with the Speedscale sidecar in `forward` or `dual` mode, configure the runtime to use the
+sidecar's forward proxy on `127.0.0.1:4140` unless you changed `proxy-out-port`.
+
+Typical settings:
+
+```bash
+export HTTP_PROXY=http://127.0.0.1:4140
+export HTTPS_PROXY=http://127.0.0.1:4140
+```
+
+If `tls-out` is enabled, also trust the Speedscale CA separately, commonly with `REQUESTS_CA_BUNDLE` for
+`requests`-based applications.
+
+See [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md) and
+[TLS Support](/getting-started/installation/sidecar/tls.md) for the shared sidecar behavior.
+
 ## Demo App
 
 - Public demo: [speedscale/demo/python](https://github.com/speedscale/demo/tree/main/python)

--- a/docs/reference/proxy_config.mdx
+++ b/docs/reference/proxy_config.mdx
@@ -147,8 +147,9 @@ export NODE_EXTRA_CA_CERTS=${HOME}/.speedscale/certs/tls.crt
 
 <TabItem value="java" label="Java">
 
-When using Java, you need to set `proxy-protocol` to `socks` or `tcp:socks`. Java has built-in system
-properties for configuring the socks proxy server, add the following `-D` system property flags:
+For HTTP or HTTPS traffic in Kubernetes, use `proxy-protocol: "http"` or `proxy-protocol: "tcp:http"` and
+configure the JVM with the standard HTTP proxy flags. For raw TCP clients that support SOCKS, use `socks` or
+`tcp:socks` instead.
 
 <Tabs>
 <TabItem value="k8s" label="Kubernetes">
@@ -174,7 +175,16 @@ spec:
 
 <TabItem value="not-k8s" label="Outside of Kubernetes">
 
+```bash
+-Dhttp.proxyHost=127.0.0.1
+-Dhttp.proxyPort=4140
+-Dhttps.proxyHost=127.0.0.1
+-Dhttps.proxyPort=4140
 ```
+
+Use SOCKS instead for clients or protocols that require it:
+
+```bash
 -DsocksProxyHost=127.0.0.1
 -DsocksProxyPort=4140
 ```

--- a/src/partials/reference/sidecar-annotations.mdx
+++ b/src/partials/reference/sidecar-annotations.mdx
@@ -156,7 +156,8 @@ viewable in the Speedscale UI. See [TLS](/getting-started/installation/sidecar/t
 ### `sidecar.speedscale.com/tls-java-tool-options`
 
 Configures the operator to add `JAVA_TOOL_OPTIONS` with TLS certificate overrides as additional
-container env vars. This setting is only used when `tls-out` is enabled.
+container env vars. This setting is only used when `tls-out` is enabled. It only covers Java truststore
+configuration and does not configure outbound proxy routing for `forward` or `dual` proxy modes.
 
 - Accepted Values:
   - `true`

--- a/src/partials/reference/sidecar-annotations.mdx
+++ b/src/partials/reference/sidecar-annotations.mdx
@@ -165,6 +165,17 @@ configuration and does not configure outbound proxy routing for `forward` or `du
 
 ---
 
+### `sidecar.speedscale.com/tls-java-tool-options-value`
+
+Overrides `JAVA_TOOL_OPTIONS` with a custom value. Use this when you need the operator to write the full
+merged JVM flag string, such as proxy flags, truststore flags, and your existing application-specific Java
+options.
+
+If both `sidecar.speedscale.com/tls-java-tool-options` and
+`sidecar.speedscale.com/tls-java-tool-options-value` are set, the custom value takes precedence.
+
+---
+
 ### `sidecar.speedscale.com/tls-in-secret`
 
 Kubernetes [TLS secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) containing


### PR DESCRIPTION
## Summary
- clarify GKE Autopilot requirements for inline sidecar mode and SmartDNS disablement
- explain that forward and dual proxy modes still require runtime-level outbound proxy configuration
- add in-cluster Java guidance and short Kubernetes sidecar notes for Go, Node.js, Python, and .NET

## Testing
- npm run build
