### PR TITLE
docs: prefer eBPF over sidecar in K8s; convert Proxymock architecture…

### DIFF
--- a/docs/getting-started/installation/install/istio.md
+++ b/docs/getting-started/installation/install/istio.md
@@ -79,7 +79,7 @@ outlined in the [Istio documentation](https://istio.io/latest/docs/setup/additio
 
 :::
 
-Follow the [installation guide](../sidecar/install.md) to install the Speedscale sidecar on your Istio workloads.
+For capture in Kubernetes with Istio, prefer enabling the [eBPF collector](/reference/ebpf-traffic-collection). If eBPF is not suitable for your workload, follow the [sidecar installation guide](../sidecar/install.md) to install the Speedscale sidecar on your Istio workloads.
 
 ## Allow Egress Speedscale Traffic (Optional)
 

--- a/docs/getting-started/installation/sidecar/annotations.md
+++ b/docs/getting-started/installation/sidecar/annotations.md
@@ -9,4 +9,8 @@ import SidecarAnnotations from '@site/src/partials/reference/sidecar-annotations
 The Speedscale sidecar can be configured with the use of annotations added to your Kubernetes workload. The
 following are the currently supported annotations:
 
+:::info Prefer eBPF in Kubernetes
+For Kubernetes traffic capture, enable the [eBPF collector](/reference/ebpf-traffic-collection) when possible. The annotations below apply when using the sidecar as a fallback.
+:::
+
 <SidecarAnnotations />

--- a/docs/getting-started/installation/sidecar/install.md
+++ b/docs/getting-started/installation/sidecar/install.md
@@ -20,8 +20,8 @@ used to collect data from an existing application.  To capture
 [traffic](/reference/glossary.md#traffic), requests to and from your
 application will need to be routed through the proxy.
 
-:::tip
-Speedscale also supports [eBPF-based traffic collection](/reference/ebpf-traffic-collection) which captures TLS traffic without certificates, proxies, or application changes.
+:::info Recommended for Kubernetes
+Prefer the [eBPF collector](/reference/ebpf-traffic-collection) for Kubernetes traffic capture. It runs as a DaemonSet, requires no app changes, and captures plaintext and TLS without cert management. Use the sidecar only when eBPF is not suitable for your workload or cluster.
 :::
 
 
@@ -32,7 +32,7 @@ Speedscale also supports [eBPF-based traffic collection](/reference/ebpf-traffic
 The [envoy](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/listeners/listeners#tcp) proxy (aka Istio) uses the same architecture to redirect traffic. Your platform or security team may already be familiar with this approach.
 :::
 
-## Installation
+## Installation (fallback)
 
 There are several ways to install the sidecar in your cluster.  See the [proxy
 configuration reference](../../../reference/proxy_config.mdx) for proxy configuration

--- a/docs/getting-started/installation/sidecar/performance.md
+++ b/docs/getting-started/installation/sidecar/performance.md
@@ -11,13 +11,17 @@ exact impact of the proxy will vary based upon your workload and conditions. For
 testing the sidecar in pre-production and then using a progressive rollout strategy in production. Due to high
 variability, Speedscale does not currently publish benchmarks.
 
+:::info Prefer eBPF in Kubernetes
+When running in Kubernetes, enable the [eBPF collector](/reference/ebpf-traffic-collection) when possible to avoid proxy-induced latency. Use the sidecar only when eBPF is not suitable for your workload or cluster.
+:::
+
 ### Testing sidecar latency in pre-production
 
 We recommend testing latency and overhead on a pre-production workload using this procedure:
 1. Add monitoring for CPU and memory to your service. Just watching a tool like [k9s](https://k9scli.io/) and is sometimes sufficient. If you want to get fancy you use other tools like [ContainIQ](https://www.containiq.com/) or [Pixie](https://github.com/pixie-io/pixie).
 2. Establish a baseline by running a consistent workload like a load test. Using Speedscale to replay and scale up volume is a great idea but you can also use existing load testing scripts.
 3. Record the CPU, memory usage and **average latency** over the course of the load test.
-4. Install the Speedscale sidecar
+4. Enable the [eBPF collector](/reference/ebpf-traffic-collection) (preferred) or install the Speedscale sidecar (fallback)
 5. Re-run the same load test.
 6. Compare results.
 

--- a/docs/getting-started/installation/sidecar/proxy-modes.md
+++ b/docs/getting-started/installation/sidecar/proxy-modes.md
@@ -26,6 +26,10 @@ while outbound capture stays empty if the workload runtime does not send traffic
 When using the annotation examples below, be sure to _add_ them to any existing annotations on your workload.
 :::
 
+:::info Prefer eBPF in Kubernetes
+For Kubernetes traffic capture, enable the [eBPF collector](/reference/ebpf-traffic-collection) when possible. The proxy modes below apply when using the sidecar as a fallback.
+:::
+
 ## Proxy Configuration
 
 Configuration for this operation mode is managed with workload annotations. You must specify the type of proxy

--- a/docs/getting-started/installation/sidecar/tls.md
+++ b/docs/getting-started/installation/sidecar/tls.md
@@ -11,6 +11,10 @@ import Mermaid from '@theme/Mermaid';
 
 TLS interception and unwrapping is not enabled by default, but can be done so with annotations to your workload.
 
+:::info Prefer eBPF in Kubernetes
+When possible, use the [eBPF collector](/reference/ebpf-traffic-collection) to capture TLS in Kubernetes without certificates or proxy configuration. The TLS guidance below applies when using the sidecar as a fallback.
+:::
+
 :::tip Remember
 When using the annotation examples below, be sure to _add_ them to any existing annotations on your workload. It's common to delete existing annotations or add the annotations in the wrong place (like on the pod instead of the deployment) in this step.
 :::

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -67,8 +67,12 @@ for all configuration options available for the Helm chart.
 Run `speedctl install`, choose "Kubernetes" and follow the prompts.
 
 The install wizard will walk you through installing the
-[Speedscale Kubernetes Operator](./installation/install/kubernetes-operator.md)
-and adding the [Speedscale Sidecar](./installation/sidecar/install.md) to your deployment.
+[Speedscale Kubernetes Operator](./installation/install/kubernetes-operator.md).
+
+Recommended next step: enable the [eBPF collector](/reference/ebpf-traffic-collection)
+to capture traffic in Kubernetes without proxies or app changes. If your
+environment or workload cannot use eBPF, fall back to the
+[Sidecar installation](./installation/sidecar/install.md).
 
 ### (Optional) Adding Image Pull Secrets
 
@@ -87,8 +91,11 @@ speedctl install --imgpullsecrets my-secret1,my-secret2p
 
 If using Kubernetes run `speedctl install`, choose "Kubernetes" and follow the prompts.
 The install wizard will walk you through installing the
-[Speedscale Kubernetes Operator](./installation/install/kubernetes-operator.md)
-and adding the [Speedscale Sidecar](./installation/sidecar/install.md) to your deployment.
+[Speedscale Kubernetes Operator](./installation/install/kubernetes-operator.md).
+
+Recommended next step: enable the [eBPF collector](/reference/ebpf-traffic-collection)
+to capture traffic in Kubernetes. If eBPF is not suitable for your
+workload or kernel, use the [Sidecar installation](./installation/sidecar/install.md) instead.
 
 Speedscale can also be used with [Docker](./installation/install/docker.md) and [locally](../reference/cli.md).
 
@@ -172,4 +179,4 @@ If you have any issues installing, check out the [troubleshooting guide](./insta
 
 At this point Speedscale is present in your cluster and you are now ready to target workloads for record and playback. If this is your first installation please continue using our multi-platform [tutorial](./tutorial.md) for a full walkthrough.
 
-If you're already an expert you can click the `Add Service` button in the UI to automatically add sidecars or install them [manually](./installation/sidecar/install.md).
+If you're already an expert you can click the `Add Service` button in the UI to target workloads for capture. Prefer enabling the [eBPF collector](/reference/ebpf-traffic-collection); if not possible, add sidecars [manually](./installation/sidecar/install.md).

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -34,7 +34,8 @@ Make sure you navigate to the `java` subdirectory within the `demo` repository.
 <TabItem value="Kubernetes">
 
 1. [Install the operator](./quick-start.md#install-speedscale-operator-optional)
-2. To deploy the demo app and sidecar, run:
+2. Recommended: enable the [eBPF collector](/reference/ebpf-traffic-collection) to capture traffic without proxies or app changes. Follow the Helm-based setup to target the demo namespace/workload.
+   - Fallback: if eBPF is not suitable in your cluster, deploy the demo app with the Speedscale sidecar by running:
 
 ```bash
 make kube-capture
@@ -46,7 +47,7 @@ make kube-capture
 kubectl -n default get pods
 ```
 
-Which should show `2/2` for the java-server pod indicating there are 2 containers (the application and the sidecar).
+Depending on your chosen capture method you may see either `1/1` (eBPF collector) or `2/2` (application + sidecar) for the `java-server` pod.
 
 ```bash
 NAME                           READY   STATUS    RESTARTS   AGE

--- a/docs/guides/ingress.md
+++ b/docs/guides/ingress.md
@@ -15,7 +15,13 @@ demonstrate how to do this specifically for clusters using
 1. A cluster with the Speedscale operator installed and with `ingress-nginx` configured as its ingress controller
 1. TLS connections are terminated at the `ingress-nginx` controller
 
-## Install the Speedscale Sidecar
+## Enable eBPF Collector (recommended)
+
+For Kubernetes ingress traffic, prefer enabling the [eBPF collector](/reference/ebpf-traffic-collection) to capture requests without modifying the ingress controller deployment. Use Helm values to enable eBPF and target the `ingress-nginx` namespace or specific workloads via capture targets or annotations.
+
+If your cluster or ingress setup cannot support eBPF, use the sidecar approach below.
+
+## Fallback: Install the Speedscale Sidecar
 
 To begin, the Speedscale sidecar must be installed on the ingress controller deployment
 `ingress-nginx-controller` in the `ingress-nginx` namespace. Begin by creating a patch YAML file for the

--- a/docs/proxymock/how-it-works/architecture.md
+++ b/docs/proxymock/how-it-works/architecture.md
@@ -6,11 +6,6 @@ sidebar_position: 1
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import AppNoProxymock from './architecture/app-no-proxymock.svg';
-import AppCapturingOutbound from './architecture/app-capturing-outbound.svg';
-import AppCapturingInbound from './architecture/app-capturing-inbound.svg';
-import AppWithMocks from './architecture/app-with-mocks.svg';
-import AppWithLoadGenerator from './architecture/app-with-load-generator.svg';
 
 # Architecture
 
@@ -25,7 +20,11 @@ This is probably close what your setup looks like.  A client making requests to
 your app's API (listening on port `8080` in this case) and your app making
 requests to various other services, APIs, databases, etc.
 
-    <AppNoProxymock />
+```mermaid
+flowchart LR
+  Client[client] --> App[your app 8080]
+  App --> Deps[dependencies API, database, etc]
+```
 
   </TabItem>
   <TabItem value="proxymock-capturing-outbound" label="Record Mocks">
@@ -34,7 +33,13 @@ your app makes to other services and the associated responses.  Once captured
 these are called [mocks](/reference/glossary.md#mock) and are written to
 artifacts in a local directory.
 
-    <AppCapturingOutbound />
+```mermaid
+flowchart LR
+  Client[client] --> App[your app 8080] --> PM[proxymock 4140]
+  PM --> Deps[dependencies API, database, etc]
+  PM --> Local[local directory]
+  style Local fill:#FDE68A,stroke:#D97706,stroke-width:1px,color:#111
+```
 
 Once the necessary env vars are set in the environment where "your app" is
 running outbound traffic from your app is routed through **proxymock** and
@@ -47,7 +52,13 @@ makes to your app the associated responses.  Once captured these are called
 [tests](/reference/glossary.md#test) and are written to artifacts in a local
 directory.
 
-    <AppCapturingInbound />
+```mermaid
+flowchart LR
+  Client[client] --> PM[proxymock 4143]
+  PM --> Local[local directory]
+  PM --> App[your app 8080] --> Deps[dependencies API, database, etc]
+  style Local fill:#FDE68A,stroke:#D97706,stroke-width:1px,color:#111
+```
 
 Requests from the client are routed through **proxymock** and captured in the
 process, but unlike outbound traffic where we can just set env vars the client
@@ -62,7 +73,12 @@ server](/reference/glossary.md#mock-server) to respond to requests from your
 app.  Mock [signatures](/proxymock/how-it-works/signature.md) are generated from the
 mock artifacts captured earlier.
 
-    <AppWithMocks />
+```mermaid
+flowchart LR
+  Client[client] --> App[your app 8080] --> PM[proxymock 4140] --> Deps[dependencies API, database, etc]
+  PM --> Local[local directory]
+  style Local fill:#FDE68A,stroke:#D97706,stroke-width:1px,color:#111
+```
 
 While dependencies can be fully replace by **proxymock**, there is a dotted line
 to indicate "passthrough", which is what happens when a request to the mock
@@ -75,7 +91,12 @@ Once **proxymock** has created [tests](/reference/glossary.md#test) from inbound
 traffic it can replay those requests back to your app. Requests are
 generated from the test artifacts captured earlier.
 
-    <AppWithLoadGenerator />
+```mermaid
+flowchart LR
+  Local[local directory] --> PM[proxymock]
+  PM --> App[your app 8080] --> Deps[dependencies API, database, etc]
+  style Local fill:#FDE68A,stroke:#D97706,stroke-width:1px,color:#111
+```
 
 In this configuration the client is fully replaced by **proxymock** which makes
 requests to your app on port `8080`.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -64,8 +64,12 @@ for all configuration options available for the Helm chart.
 Run `speedctl install`, choose "Kubernetes" and follow the prompts.
 
 The install wizard will walk you through installing the
-[Speedscale Kubernetes Operator](./getting-started/installation/install/kubernetes-operator.md)
-and adding the [Speedscale Sidecar](./getting-started/installation/sidecar/install.md) to your deployment.
+[Speedscale Kubernetes Operator](./getting-started/installation/install/kubernetes-operator.md).
+
+Recommended next step: enable the [eBPF collector](/reference/ebpf-traffic-collection)
+to capture traffic in Kubernetes without proxies or app changes. If your
+environment or workload cannot use eBPF, fall back to the
+[Sidecar installation](./getting-started/installation/sidecar/install.md).
 
 ### (Optional) Adding Image Pull Secrets
 
@@ -84,8 +88,11 @@ speedctl install --imgpullsecrets my-secret1,my-secret2p
 
 If using Kubernetes run `speedctl install`, choose "Kubernetes" and follow the prompts.
 The install wizard will walk you through installing the
-[Speedscale Kubernetes Operator](./getting-started/installation/install/kubernetes-operator.md)
-and adding the [Speedscale Sidecar](./getting-started/installation/sidecar/install.md) to your deployment.
+[Speedscale Kubernetes Operator](./getting-started/installation/install/kubernetes-operator.md).
+
+Recommended next step: enable the [eBPF collector](/reference/ebpf-traffic-collection)
+to capture traffic in Kubernetes. If eBPF is not suitable for your
+workload or kernel, use the [Sidecar installation](./getting-started/installation/sidecar/install.md) instead.
 
 Speedscale can also be used with [Docker](./getting-started/installation/install/docker.md) and [locally](./guides/cli.md).
 
@@ -169,4 +176,4 @@ If you have any issues installing, check out the [troubleshooting guide](./getti
 
 At this point Speedscale is present in your cluster and you are now ready to target workloads for record and playback. If this is your first installation please continue using our multi-platform [tutorial](./tutorial.md) for a full walkthrough.
 
-If you're already an expert you can click the `Add Service` button in the UI to automatically add sidecars or install them [manually](./getting-started/installation/sidecar/install.md).
+If you're already an expert you can click the `Add Service` button in the UI to target workloads for capture. Prefer enabling the [eBPF collector](/reference/ebpf-traffic-collection); if not possible, add sidecars [manually](./getting-started/installation/sidecar/install.md).

--- a/docs/reference/api-first.md
+++ b/docs/reference/api-first.md
@@ -16,7 +16,7 @@ There should be little or no difference between the capabilities offered using e
 
 Speedscale is designed to either run standalone or as part of a wider testing platform. For example, let's imagine we want to record new traffic from production every hour and make it available in a staging environment. This is accomplished using only Speedscale by setting up an hourly [schedule](https://app.speedscale.com/schedules) for recording and/or replay. No external components or tools are required for the full lifecycle of this activity.
 
-However, many larger enterprises wish to use an existing test orchestration platform that was likely built in-house. This is fully supported and allows whatever degree of control is desired. Using the same example as above, the custom orchestrator can use its own scheduler and call the `speedctl infra sidecar` command every hour to trigger Speedscale. Either approach will produce an hourly snapshot of production data except one is controlled by an outside system and one is fully contained within Speedscale.
+However, many larger enterprises wish to use an existing test orchestration platform that was likely built in-house. This is fully supported and allows whatever degree of control is desired. Using the same example as above, the custom orchestrator can manage eBPF-based capture via Helm values/annotations (preferred in Kubernetes; see [eBPF collector](/reference/ebpf-traffic-collection)) or, if eBPF is not suitable, invoke sidecar-based workflows (e.g., `speedctl infra sidecar`). Either approach will produce an hourly snapshot of production data except one is controlled by an outside system and one is fully contained within Speedscale.
 
 # Exporting Data
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -88,7 +88,7 @@ speedscale-operator-d9cc9c794-mtcdp     1/1     Running   0          7d6h
 
 **java-server/client (optional)** - A simple demo app deployed in the `speedscale` namespace that can be easily turned off.
 
-The sidecar and eBPF DaemonSet capture methods are detailed in the [Ingest](#ingest-only) section below. The operator installation does not automatically deploy either capture method.
+The eBPF DaemonSet and sidecar capture methods are detailed in the [Ingest](#ingest-only) section below. The operator installation does not automatically deploy either capture method.
 
 :::note
 All connections to Speedscale Cloud are initiated outbound from your cluster. Speedscale does not require listener ports to be opened.
@@ -100,33 +100,7 @@ All connections to Speedscale Cloud are initiated outbound from your cluster. Sp
 
 ## Ingest Only
 
-During traffic ingest, Speedscale utilizes a data pipeline that is optimized for data masking, filtering and high volume. Speedscale offers two capture methods: a **sidecar proxy** injected into each pod, or an **eBPF DaemonSet** (`nettap`) that observes traffic at the node level without modifying workloads. Both methods forward captured traffic to the in-cluster forwarder where DLP filtering and PII redaction occur before data leaves the cluster.
-
-### Sidecar Capture
-
-```mermaid
-graph LR
-    subgraph pod["Application Pod"]
-        app["App Container"]
-        sidecar["Sidecar<br/>speedscale-goproxy"]
-    end
-
-    forwarder["Forwarder<br/>DLP & Filtering"]
-    cloud["Speedscale Cloud"]
-
-    app <-->|traffic| sidecar
-    sidecar -->|traffic data| forwarder
-    forwarder -->|"filtered data<br/>PII redacted"| cloud
-```
-
-**sidecar** - A listener proxy injected into each application pod, similar to an Envoy sidecar. The sidecar intercepts inbound and outbound traffic and forwards it to the in-cluster forwarder.
-
-Pods with the speedscale sidecar injected will have a new container named `speedscale-goproxy`:
-
-```bash
-kubectl -n speedscale get pods java-server-5786d56974-pv765 -o jsonpath='{.spec.containers[*].name}'
-speedscale-goproxy java-server
-```
+During traffic ingest, Speedscale utilizes a data pipeline that is optimized for data masking, filtering and high volume. Speedscale offers two capture methods: an **eBPF DaemonSet** (`nettap`) that observes traffic at the node level without modifying workloads, or a **sidecar proxy** injected into each pod. Both methods forward captured traffic to the in-cluster forwarder where DLP filtering and PII redaction occur before data leaves the cluster.
 
 ### eBPF Capture
 
@@ -153,6 +127,32 @@ Verify the nettap DaemonSet is running:
 
 ```bash
 kubectl -n speedscale get daemonset nettap
+```
+
+### Sidecar Capture
+
+```mermaid
+graph LR
+    subgraph pod["Application Pod"]
+        app["App Container"]
+        sidecar["Sidecar<br/>speedscale-goproxy"]
+    end
+
+    forwarder["Forwarder<br/>DLP & Filtering"]
+    cloud["Speedscale Cloud"]
+
+    app <-->|traffic| sidecar
+    sidecar -->|traffic data| forwarder
+    forwarder -->|"filtered data<br/>PII redacted"| cloud
+```
+
+**sidecar** - A listener proxy injected into each application pod, similar to an Envoy sidecar. The sidecar intercepts inbound and outbound traffic and forwards it to the in-cluster forwarder.
+
+Pods with the speedscale sidecar injected will have a new container named `speedscale-goproxy`:
+
+```bash
+kubectl -n speedscale get pods java-server-5786d56974-pv765 -o jsonpath='{.spec.containers[*].name}'
+speedscale-goproxy java-server
 ```
 
 :::tip

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -35,7 +35,8 @@ Make sure you navigate to the `java` subdirectory within the `demo` repository.
 <TabItem value="Kubernetes">
 
 1. [Install the operator](./quick-start.md#install-speedscale-operator-optional)
-2. To deploy the demo app and sidecar, run:
+2. Recommended: enable the [eBPF collector](/reference/ebpf-traffic-collection) to capture traffic without proxies or app changes. Follow the Helm-based setup to target the demo namespace/workload.
+   - Fallback: if eBPF is not suitable in your cluster, deploy the demo app with the Speedscale sidecar by running:
 
 ```bash
 make kube-capture
@@ -47,7 +48,7 @@ make kube-capture
 kubectl -n default get pods
 ```
 
-Which should show `2/2` for the java-server pod indicating there are 2 containers (the application and the sidecar).
+Depending on your chosen capture method you may see either `1/1` (eBPF collector) or `2/2` (application + sidecar) for the `java-server` pod.
 
 ```bash
 NAME                           READY   STATUS    RESTARTS   AGE

--- a/src/partials/reference/sidecar-annotations.mdx
+++ b/src/partials/reference/sidecar-annotations.mdx
@@ -1,3 +1,7 @@
+:::info Prefer eBPF in Kubernetes
+For Kubernetes traffic capture, enable the [eBPF collector](/reference/ebpf-traffic-collection) when possible. The annotations in this reference apply when using the sidecar as a fallback.
+:::
+
 ### `sidecar.speedscale.com/inject`
 
 Add the sidecar to your: deployment, job, stateful set or daemon set.


### PR DESCRIPTION
## Summary
- Prefer eBPF over sidecar for Kubernetes capture throughout docs; keep sidecar as fallback where eBPF is not suitable.
- Update Deployment Architecture to list eBPF capture first and sidecar second.
- Convert Proxymock Architecture page diagrams from Excalidraw SVGs to Mermaid, with requested node names, flows, and styling.

## What’s Included
- eBPF-first guidance:
  - getting-started/quick-start.md and quick-start.md (CLI sections + Next Steps)
  - getting-started/installation/install/istio.md (recommend eBPF first)
  - guides/ingress.md (eBPF recommended; sidecar as fallback)
  - reference/api-first.md (mention eBPF orchestration; sidecar as fallback)
  - getting-started/installation/sidecar/* (annotations, install, performance, proxy-modes, tls) — added notes to prefer eBPF when on Kubernetes
  - src/partials/reference/sidecar-annotations.mdx — added eBPF preference note
- Deployment Architecture (reference/architecture.md):
  - Reword overview to reference “eBPF DaemonSet and sidecar”
  - Swap Ingest subsections: “eBPF Capture” first, “Sidecar Capture” second
- Proxymock Architecture (proxymock/how-it-works/architecture.md):
  - Replace 5 SVGs with Mermaid
  - Record Mocks: client → your app 8080 → proxymock 4140 with branches to dependencies and local directory
  - Record Tests: client → proxymock 4143 branching to local directory and to your app 8080 → dependencies
  - Mock Server: client → your app 8080 → proxymock 4140 → dependencies; plus proxymock → local directory
  - Replay/Load Generator: local directory → proxymock → your app 8080 → dependencies
  - Remove edge labels; fix Mermaid parse errors; standardize node labels
  - Highlight “local directory” nodes with a distinct style (fill/stroke)

## Reasoning
- eBPF capture reduces operational overhead (no per-pod proxies), captures TLS without app changes, and is recommended default in Kubernetes.
- Sidecar remains documented for workloads/kernels where eBPF is not viable.

## Verification
- Local Docusaurus build succeeds (mermaid enabled). Diagrams render without parse errors.

## Follow-ups (optional)
- Align color tokens for Mermaid node styles with design palette if desired.
- Consider adding short “When to use eBPF vs sidecar” decision table in Quick Start.
