### PR TITLE
docs: move Datadog Synthetics to ProxyMock guides navigation

### DIFF
--- a/docs/proxymock/guides/index.md
+++ b/docs/proxymock/guides/index.md
@@ -4,7 +4,7 @@ description: "Explore practical how-to guides for using ProxyMock effectively in
 sidebar_position: 3
 ---
 
-import { GrpcCard, OpenApiCard, ModifyRrpairsCard, LlmSimulationCard } from '@site/src/components/Cards';
+import { GrpcCard, OpenApiCard, ModifyRrpairsCard, LlmSimulationCard, DatadogSyntheticsCard } from '@site/src/components/Cards';
 
 # Guides
 
@@ -12,8 +12,8 @@ This section contains how-to guides for practical uses of **proxymock**.
 
 <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1rem', marginTop: '2rem' }}>
   <LlmSimulationCard />
+  <DatadogSyntheticsCard />
   <GrpcCard />
   <OpenApiCard />
   <ModifyRrpairsCard />
 </div>
-

--- a/sidebars.js
+++ b/sidebars.js
@@ -110,7 +110,6 @@ const sidebars = {
             "guides/prometheus",
             "guides/signature-refinement-guide",
             "guides/local-capture",
-            "proxymock/guides/datadog-synthetics/index",
             "guides/manual_snapshot",
             "guides/identify-session",
             "guides/extract-replace",

--- a/src/components/Cards/DatadogSyntheticsCard.js
+++ b/src/components/Cards/DatadogSyntheticsCard.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import Card from '@site/src/components/Card';
+import CardHeader from '@site/src/components/Card/CardHeader';
+import CardBody from '@site/src/components/Card/CardBody';
+import CardFooter from '@site/src/components/Card/CardFooter';
+
+const DatadogSyntheticsCard = () => {
+  return (
+    <Card shadow="md">
+      <CardHeader
+        style={{ backgroundColor: '#f8f9fa', borderBottom: '1px solid #e0e0e0' }}
+        textAlign="center"
+        weight="Bold"
+      >
+        <h3 style={{ margin: 0, marginBottom: '1rem' }}>Datadog Synthetics</h3>
+      </CardHeader>
+      <CardBody className="padding-vert--md">
+        Export recorded proxymock traffic into Datadog Synthetics tests with automatic
+        auth redaction and step chaining.
+      </CardBody>
+      <CardFooter style={{ backgroundColor: '#f8f9fa', textAlign: 'center' }}>
+        <a href="/proxymock/guides/datadog-synthetics/" className="button button--primary">Open Guide</a>
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default DatadogSyntheticsCard;

--- a/src/components/Cards/index.js
+++ b/src/components/Cards/index.js
@@ -22,3 +22,4 @@ export { default as AICodeGenerationCard } from './AICodeGenerationCard';
 export { default as LearningResourcesCard } from './LearningResourcesCard';
 export { default as CommunitySupportCard } from './CommunitySupportCard';
 export { default as LlmSimulationCard } from './LlmSimulationCard';
+export { default as DatadogSyntheticsCard } from './DatadogSyntheticsCard';


### PR DESCRIPTION
## Summary
- keep Datadog Synthetics discoverable in the ProxyMock Guides dashboard by adding a dedicated guide card on `docs/proxymock/guides/`
- remove the misplaced `proxymock/guides/datadog-synthetics/index` entry from the platform-level `Guides -> Advanced Topics` sidebar group
- add a reusable `DatadogSyntheticsCard` component and export so ProxyMock guide links stay aligned with product navigation boundaries

## Validation
- `yarn build`