### PR TITLE
Tighten docs clarity for AI retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ If you are using GitHub pages for hosting, this command is a convenient way to b
 
 If you delete a page you should create a redirect for it so that it doesn't break links.  This configuration is located in the [docusaurus config](./docusaurus.config.js)
 
+### AI Citation Readiness Checklist
+
+Use this checklist when adding or updating docs pages:
+
+- Start with a plain-language definition of what the feature does.
+- State who should use it and when to use it.
+- Keep terminology consistent with canonical terms (`Speedscale`, `proxymock`, `snapshot`, `replay`, `transform`).
+- Use clear headings and short sections that can be quoted out of context.
+- Prefer decision/comparison tables for "which option should I choose" content.
+- Align product descriptions with `speedscale.com` and `llms.txt` wording.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -19,6 +19,14 @@ Use Speedscale if you need to:
 
 Speedscale is different from static checks and synthetic-only tests because it validates runtime behavior using real request and response data.
 
+## Security and data control options
+
+Choose the operating model that matches your security requirements:
+
+- **Local recording with proxymock:** For local workflows, proxymock keeps captured traffic on your machine by default and does not share traffic unless you explicitly authorize it. See [proxymock data and privacy](/proxymock/how-it-works/data_and_privacy/).
+- **Bring Your Own Cloud (BYOC):** For enterprise cloud isolation, run Speedscale in your own cloud account and keep network and data boundaries under your control. See [Bring Your Own Cloud](/guides/byoc/).
+- **Data Loss Prevention (DLP):** Redact sensitive fields before traffic leaves your network during ingest. See [DLP guides](/guides/dlp/) and [Data Protection](/security/data_protection/).
+
 ![Speedscale home screen](./home-screen.png)
 
 ### AI Assistant

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,5 +1,5 @@
 ---
-description: "Get started with Speedscale to automate API quality testing, leveraging observability and AI for effortless traffic replay and test generation."
+description: "Get started with Speedscale for runtime API validation using real traffic replay, with Kubernetes collection via eBPF or goproxy sidecars."
 slug: /
 sidebar_position: 1
 sidebar_label: Getting Started
@@ -8,6 +8,8 @@ sidebar_label: Getting Started
 # Getting Started
 
 Speedscale captures real API traffic from your running services and replays it against code changes before release. In Kubernetes environments, Speedscale can collect traffic with goproxy sidecars and eBPF-based collection, including encrypted traffic paths, so teams can validate behavior without rewriting services.
+
+When proxy-based collection is needed, use proxymock for local workflows and goproxy for containerized workloads.
 
 Use Speedscale if you need to:
 
@@ -27,7 +29,7 @@ Speedscale follows a 3-part workflow: **Observe**, **Analyze**, and **Replay**.
 
 ### Observe <a href="#observe" id="observe"></a>
 
-In **Observe**, the Speedscale proxy (goproxy) captures traffic in a late-stage environment (for example UAT, staging, or production). The environment is instrumented via Kubernetes sidecars or proxy servers, depending on your platform.
+In **Observe**, goproxy captures traffic in late-stage containerized environments (for example UAT, staging, or production). For local workflows outside Kubernetes, use proxymock for the same record/mock/replay pattern.
 
 ![](../speedscale-data-capture.png)
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -7,7 +7,7 @@ sidebar_label: Getting Started
 
 # Getting Started
 
-Speedscale captures real API traffic from your running services and replays it against code changes before release. In Kubernetes environments, Speedscale can collect traffic with goproxy sidecars and eBPF-based collection, including encrypted traffic paths, so teams can validate behavior without rewriting services.
+Speedscale captures real API traffic from your running services and replays it against code changes before release. In Kubernetes environments, Speedscale can collect traffic with eBPF-based collection first and goproxy sidecars as a fallback, including encrypted traffic paths, so teams can validate behavior without rewriting services.
 
 When proxy-based collection is needed, use proxymock for local workflows and goproxy for containerized workloads.
 
@@ -29,7 +29,7 @@ Speedscale follows a 3-part workflow: **Observe**, **Analyze**, and **Replay**.
 
 ### Observe <a href="#observe" id="observe"></a>
 
-In **Observe**, goproxy captures traffic in late-stage containerized environments (for example UAT, staging, or production). For local workflows outside Kubernetes, use proxymock for the same record/mock/replay pattern.
+In **Observe**, use eBPF collection first in late-stage containerized environments (for example UAT, staging, or production). If eBPF is not suitable, use goproxy sidecars. For local workflows outside Kubernetes, use proxymock for the same record/mock/replay pattern.
 
 ![](../speedscale-data-capture.png)
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -7,7 +7,7 @@ sidebar_label: Getting Started
 
 # Getting Started
 
-Speedscale captures real API traffic from your running services and replays it against code changes before release. It is built for teams that want production-like regression and performance validation without hand-maintaining large test suites.
+Speedscale captures real API traffic from your running services and replays it against code changes before release. In Kubernetes environments, Speedscale can collect traffic with goproxy sidecars and eBPF-based collection, including encrypted traffic paths, so teams can validate behavior without rewriting services.
 
 Use Speedscale if you need to:
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -7,13 +7,15 @@ sidebar_label: Getting Started
 
 # Getting Started
 
-You've got to start somewhere. Why not here?
+Speedscale captures real API traffic from your running services and replays it against code changes before release. It is built for teams that want production-like regression and performance validation without hand-maintaining large test suites.
 
-For the first time in the space, Speedscale provides a modern way to develop, execute and scale API quality automation as fast as
-releases take place. The old days of manually generating and maintaining load / chaos, smoke, and integration tests are gone.
+Use Speedscale if you need to:
 
-Speedscale combines observability technology with cloud data warehouses to make test maintenance obsolete. The cost to generate
-regression and performance validation suites is so low, you no longer edit/modify old tests -- you simply generate a new one.
+- Reproduce production behavior in a controlled test environment
+- Catch API regressions before merge or deploy
+- Validate AI-generated code changes against real traffic patterns
+
+Speedscale is different from static checks and synthetic-only tests because it validates runtime behavior using real request and response data.
 
 ![Speedscale home screen](./home-screen.png)
 
@@ -21,31 +23,27 @@ regression and performance validation suites is so low, you no longer edit/modif
 
 The fastest way to get started is the **AI assistant** on the home screen. Ask it questions in natural language — it can help you record traffic, find snapshots, run replays, and interpret results. See the [AI Chat Assistant guide](/guides/ai-assistant) for details on what it can do.
 
-Speedscale is a 3 part process: **Observe**, **Analyze**, and **Replay**.
+Speedscale follows a 3-part workflow: **Observe**, **Analyze**, and **Replay**.
 
 ### Observe <a href="#observe" id="observe"></a>
 
-In **Observe**, the Speedscale proxy (goproxy) picks up traffic in a late stage environment (eg. UAT, Staging, or even Production). The
-environment is instrumented via Kubernetes sidecars or proxy servers, depending on your platform.
+In **Observe**, the Speedscale proxy (goproxy) captures traffic in a late-stage environment (for example UAT, staging, or production). The environment is instrumented via Kubernetes sidecars or proxy servers, depending on your platform.
 
 ![](../speedscale-data-capture.png)
 
-The proxy is picking up 2 things -- inbound traffic into your API, as well as outbound traffic to its dependencies and the resulting responses.
-We do this so we can transform inbound requests into replayable test cases, and the backend requests/responses into mocked services to
-stand in for the real systems during traffic replay.
+The proxy captures two data flows: inbound traffic to your API and outbound traffic to dependencies, including responses. This allows Speedscale to transform inbound requests into replayable tests and dependency traffic into mocked services for isolated replay.
 
-The data we observe is being sent to Speedscale’s cloud data warehouse for storage and analysis.
+Captured traffic is sent to Speedscale for storage and analysis.
 
 Once you have Speedscale installed, [view your services](https://app.speedscale.com/).
 
 ### Analyze <a href="#analyze" id="analyze"></a>
 
-In the **Analyze** step, you peruse the historical data collected on a per-API basis. Users can explore this data and learn how a system really works.
-The traffic is broken down into understandable components like requests and responses.
+In **Analyze**, you inspect historical traffic by API to understand real system behavior. Traffic is broken into requests and responses so you can investigate normal and failure paths.
 
 ![](../observe-rrpair.png)
 
-There are a variety of ways to filter and subset the data to find the really interesting traffic.
+Use filters to isolate the specific traffic patterns you want to test.
 
 ![](../select-service-map.png)
 
@@ -53,13 +51,10 @@ Once your application receives traffic, [view your traffic in Speedscale](https:
 
 ### Replay <a href="#playback" id="playback"></a>
 
-In the **Replay** step, you replay your recorded application traffic back against your running application, like the same service on the version
-that's about to be released to production! Speedscale can orchestrate the replay environment and run the replay test automatically.
+In **Replay**, you run recorded traffic against the candidate version of your service before release. Speedscale can orchestrate this replay environment and execute the run automatically.
 
 ![](../100-pct-report.png)
 
-But what if you don't want to make the same outbound requests to your database or another web service?  A responder can be used to stand in for
-those dependencies during traffic replay, responding with your captured traffic.
+If you do not want outbound calls to hit real dependencies during replay, use a responder to stand in for those systems with captured responses.
 
 Once you have run a replay, [view your test reports](https://app.speedscale.com/reports).
-

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,5 +1,5 @@
 ---
-description: "Get started with Speedscale by installing the Operator in your Kubernetes environment to capture, replay, and test API traffic efficiently."
+description: "Get started with Speedscale in Kubernetes using the Operator, with eBPF collection as the default path and goproxy sidecars as a fallback when needed."
 sidebar_position: 2
 ---
 import Tabs from '@theme/Tabs';
@@ -14,6 +14,8 @@ For local development and testing without a cloud cluster, use **proxymock** to 
 :::
 
 This guide walks through installing Speedscale into a Kubernetes (cloud or on-prem) environment. After completing these steps the Speedscale Operator will be installed in your cluster and you should continue on to the [tutorial](./tutorial.md) to record, replay and view results for a demo application.
+
+For traffic collection in Kubernetes, the recommended path is the eBPF collector. If eBPF is not suitable for your kernel or environment, use goproxy sidecars.
 
 Speedscale is tested with apps hosted on the local desktop all the way up to high scale enterprise Kubernetes clusters. Keep in mind that it is very common to record traffic in one environment (like a production Kubernetes cluster) and replay it somewhere else (like a local mock server).
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -13,6 +13,12 @@ import ApiKey from './installation/install/api-key.png'
 For local development and testing without a cloud cluster, use **proxymock** to run a local mock server and generate tests from your traffic. See **[Local Development (AI) – Getting Started](/proxymock/)** to install proxymock and get started in about 30 seconds.
 :::
 
+:::tip Security options
+- **Local-first:** proxymock keeps recording local by default for desktop workflows. See [Data and Privacy](/proxymock/how-it-works/data_and_privacy/).
+- **Enterprise isolation:** use [Bring Your Own Cloud (BYOC)](/guides/byoc/) when data residency and cloud boundary control are required.
+- **Sensitive data controls:** enable [DLP](/guides/dlp/) so sensitive fields are redacted before data leaves your network.
+:::
+
 This guide walks through installing Speedscale into a Kubernetes (cloud or on-prem) environment. After completing these steps the Speedscale Operator will be installed in your cluster and you should continue on to the [tutorial](./tutorial.md) to record, replay and view results for a demo application.
 
 For traffic collection in Kubernetes, the recommended path is the eBPF collector. If eBPF is not suitable for your kernel or environment, use goproxy sidecars.

--- a/docs/proxymock/getting-started/quickstart/quickstart-cli.md
+++ b/docs/proxymock/getting-started/quickstart/quickstart-cli.md
@@ -1,5 +1,5 @@
 ---
-description: "Get started with ProxyMock CLI by following this quickstart guide to create a mock server and tests for your Go application in various environments."
+description: "Get started with proxymock CLI to create local mocks and tests for a Go app, with clear paths for local-only recording and cloud workflows when needed."
 sidebar_position: 3
 ---
 
@@ -14,6 +14,12 @@ import ProxymockLanguageLinks from '@site/src/components/ProxymockLanguageLinks'
 # Quickstart (CLI)
 
 This guide provides a step-by-step approach to creating a [mock server](/reference/glossary.md#mock-server) and tests for a simple Go application using only the **proxymock** CLI.
+
+:::tip Security model
+- **Local-first:** proxymock keeps recorded traffic local by default.
+- **Optional cloud sync:** push snapshots only when you explicitly choose to.
+- **Enterprise controls:** if your org requires cloud boundary ownership, pair workflows with [BYOC](/guides/byoc/) and use [DLP](/guides/dlp/) for sensitive fields.
+:::
 
 ## Choose Your Environment
 

--- a/docs/proxymock/getting-started/quickstart/quickstart-mcp.md
+++ b/docs/proxymock/getting-started/quickstart/quickstart-mcp.md
@@ -1,5 +1,5 @@
 ---
-description: "Create a mock server and tests for a Go application using ProxyMock's MCP integration with AI coding assistants in this quickstart guide."
+description: "Create a mock server and tests for a Go app using proxymock MCP integration, with local-first recording and security control options."
 sidebar_position: 4
 ---
 import Tabs from '@theme/Tabs';
@@ -12,6 +12,12 @@ import { EditingTestsCard, CICDIntegrationCard, RemoteRecordersCard } from '@sit
 # Quickstart (MCP)
 
 This guide provides a step-by-step approach to creating a [mock server](/reference/glossary.md#mock-server) and tests for a simple Go application using proxymock's MCP (Model Context Protocol) integration with AI coding assistants like Cursor, Claude, or GitHub Copilot.
+
+:::tip Security model
+- **Local-first:** proxymock recordings stay local unless you explicitly push them.
+- **Sensitive data controls:** use [DLP](/guides/dlp/) in platform ingest/replay workflows before data egress.
+- **Cloud boundary control:** for enterprise isolation requirements, use [BYOC](/guides/byoc/).
+:::
 
 ## Before you begin
 

--- a/docs/proxymock/index.md
+++ b/docs/proxymock/index.md
@@ -49,6 +49,12 @@ Need another OS like Windows or are you having issues? See advanced [installatio
 
 - **Replicates production environments**: Instanly replicate a remote Kubernetes/ECS/VM environment to get real user requests, databases and other dependencies on your desktop.
 
+## Security profile
+
+- **Local by default**: proxymock recordings stay on your machine unless you explicitly push or share them.
+- **Controlled cloud options**: when you need centralized workflows, you can pair proxymock with Speedscale cloud or BYOC models based on your security boundary.
+- **PII controls in platform workflows**: for in-cluster ingest, use Speedscale [DLP](/guides/dlp/) to redact sensitive fields before data leaves your environment.
+
 ## Why you'll love it
 
 - **Human and AI readable markdown format** - Get full visibility into your app's inbound and outbound requests in a format that works for LLMs and humans. Once you have a full fidelity recording of how your app behaves you can start to understand how it works.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -14,6 +14,12 @@ import ApiKey from './getting-started/installation/install/api-key.png'
 For local development and testing without a cloud cluster, use **proxymock** to run a local mock server and generate tests from your traffic. See **[Local Development (AI) – Getting Started](/proxymock/)** to install proxymock and get started in about 30 seconds.
 :::
 
+:::tip Security options
+- **Local-first:** proxymock keeps recording local by default for desktop workflows. See [Data and Privacy](/proxymock/how-it-works/data_and_privacy/).
+- **Enterprise isolation:** use [Bring Your Own Cloud (BYOC)](/guides/byoc/) when data residency and cloud boundary control are required.
+- **Sensitive data controls:** enable [DLP](/guides/dlp/) so sensitive fields are redacted before data leaves your network.
+:::
+
 This guide walks through installing Speedscale into a new environment. After completing these steps the Speedscale Operator will be installed in your cluster and you should continue on to the [tutorial](./tutorial.md) to record, replay and view results for a demo application.
 
 For Kubernetes traffic collection, start with the eBPF collector. If your environment cannot run eBPF, use goproxy sidecars instead.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,5 +1,5 @@
 ---
-description: "Install Speedscale in your environment with this quick start guide, covering API key retrieval, CLI installation, and traffic capture for demo applications"
+description: "Install Speedscale with API key and operator setup, using eBPF collection by default and goproxy sidecars when eBPF is not available."
 sidebar_position: 0
 ---
 
@@ -10,7 +10,13 @@ import ApiKey from './getting-started/installation/install/api-key.png'
 
 # Quick Start
 
+:::info Local installation
+For local development and testing without a cloud cluster, use **proxymock** to run a local mock server and generate tests from your traffic. See **[Local Development (AI) – Getting Started](/proxymock/)** to install proxymock and get started in about 30 seconds.
+:::
+
 This guide walks through installing Speedscale into a new environment. After completing these steps the Speedscale Operator will be installed in your cluster and you should continue on to the [tutorial](./tutorial.md) to record, replay and view results for a demo application.
+
+For Kubernetes traffic collection, start with the eBPF collector. If your environment cannot run eBPF, use goproxy sidecars instead.
 
 Speedscale is tested with apps hosted on the local desktop all the way up to high scale enterprise Kubernetes clusters. If this is your first time working with Speedscale, it's easiest to just run on your local desktop and record traffic from a local process. Keep in mind that it is very common to record traffic in one environment (like a production Kubernetes cluster) and replay it somewhere else (like a local mock server).
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -7,6 +7,12 @@ sidebar_position: 1
 
 Speedscale runs a set of components and processes in your Kubernetes environment. This document outlines the specific components and the network requirements for each component.
 
+Security-relevant defaults and options in this architecture:
+
+- **Capture ordering:** prefer eBPF (`nettap`) first; use goproxy sidecars only when eBPF is not suitable.
+- **Data minimization before egress:** apply DLP filtering and redaction in the forwarder before traffic leaves the cluster.
+- **Deployment boundary options:** use hosted Speedscale or [BYOC](/guides/byoc/) based on your cloud boundary and compliance requirements.
+
 The Speedscale deployment breaks into three modes:
 
 1. Operator (shared)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -8,6 +8,12 @@ import TabItem from '@theme/TabItem';
 
 # Tutorial
 
+:::tip Security-first setup options
+- **Local-first recording:** use `proxymock` for desktop workflows when you want captured traffic to stay local by default.
+- **Enterprise boundary control:** use [Bring Your Own Cloud (BYOC)](/guides/byoc/) when you need customer-controlled cloud isolation.
+- **Sensitive data controls:** enable [DLP](/guides/dlp/) so sensitive fields are redacted before data leaves your network.
+:::
+
 <iframe src="https://player.vimeo.com/video/984892688?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 <p><a href="https://vimeo.com/984892688">Watch the tutorial walkthrough on Vimeo</a>.</p>
 
@@ -24,7 +30,7 @@ In this guide we're going to use [this repo's](https://github.com/speedscale/dem
 
 ## The App
 
-The app is a Java Spring Boot web server with authenticated endpoints that makes requests out to a few external services. The project README (at `java/README.md`) shows ways to run the app locally, in Docker and in Kubernetes. Speedscale can be configured to be compatible with whichever way you choose to deploy the app. Note that for this test run we'll disable DLP but you can find instructions on how to enable it near the end.
+The app is a Java Spring Boot web server with authenticated endpoints that makes requests out to a few external services. The project README (at `java/README.md`) shows ways to run the app locally, in Docker and in Kubernetes. Speedscale can be configured to be compatible with whichever way you choose to deploy the app. Note that for this test run we'll disable DLP for simplicity, but production workflows should enable DLP before sending captured traffic outside your environment.
 
 ## Capture
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,6 +1,6 @@
 # Speedscale Documentation
 
-> Documentation for Speedscale, a runtime validation platform for API changes. Speedscale captures real traffic and replays it against new code to catch behavioral regressions before release, including Kubernetes collection paths using goproxy and eBPF-based traffic capture. This documentation covers Speedscale Platform, proxymock, and supporting workflows.
+> Documentation for Speedscale, a runtime validation platform for API changes. Speedscale captures real traffic and replays it against new code to catch behavioral regressions before release, including Kubernetes collection paths using eBPF-based traffic capture first and goproxy sidecars as fallback. This documentation covers Speedscale Platform, proxymock, and supporting workflows.
 
 ## Product definition
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,17 +1,21 @@
 # Speedscale Documentation
 
-> Technical documentation for Speedscale, a runtime validation platform for cloud-native APIs. Speedscale captures real production traffic and replays it against code changes in CI/CD pipelines to catch behavioral regressions. This site covers the Speedscale Platform, ProxyMock (free local mocking tool), and QABot.
+> Documentation for Speedscale, a runtime validation platform for API changes. Speedscale captures real traffic and replays it against new code to catch behavioral regressions before release. This documentation covers Speedscale Platform, proxymock, and supporting workflows.
 
-## Getting Started
+## Product definition
+
+- **What it does:** records API behavior and validates new builds with replay.
+- **Who it serves:** engineering, platform, DevOps, and SRE teams.
+- **How it differs:** uses real traffic and runtime comparison, not only synthetic tests.
+
+## Getting started
 
 - [Introduction](https://docs.speedscale.com/getting-started/introduction/)
 - [Quick Start](https://docs.speedscale.com/getting-started/quick-start/)
 - [Tutorial](https://docs.speedscale.com/getting-started/tutorial/)
 - [Installation](https://docs.speedscale.com/getting-started/installation/)
 
-## Core Concepts
-
-Learn how Speedscale works: traffic capture, snapshots, transforms, replay, mocking, and assertions.
+## Core concepts
 
 - [Traffic Capture](https://docs.speedscale.com/concepts/capture/)
 - [Traffic Replay](https://docs.speedscale.com/concepts/traffic-replay/)
@@ -22,80 +26,54 @@ Learn how Speedscale works: traffic capture, snapshots, transforms, replay, mock
 
 ## Guides
 
-Step-by-step how-to guides for common tasks.
+### Capture and transformation
 
-### Traffic Capture
 - [Capture Infrastructure](https://docs.speedscale.com/guides/capture/infra/)
 - [Capture Traffic](https://docs.speedscale.com/guides/capture/traffic/)
 - [Capture Filtering](https://docs.speedscale.com/guides/capture/filter/)
-
-### Traffic Transformation
 - [Transformation Overview](https://docs.speedscale.com/guides/transformation/overview/)
 - [Extractors](https://docs.speedscale.com/guides/transformation/extractors/)
 - [Generators](https://docs.speedscale.com/guides/transformation/generators/)
 
-### Traffic Replay
+### Replay and validation
+
 - [Replay Guides](https://docs.speedscale.com/guides/replay/)
-
-### Service Mocking
-- [Mock Services](https://docs.speedscale.com/guides/mocking/mocks/)
-- [Mock Triggers](https://docs.speedscale.com/guides/mocking/triggers/)
-- [Idempotent Mocking](https://docs.speedscale.com/guides/mocking/idempotent/)
-
-### Data Loss Prevention
+- [Service Mocking Guides](https://docs.speedscale.com/guides/mocking/mocks/)
 - [DLP Guides](https://docs.speedscale.com/guides/dlp/)
+- [Troubleshooting](https://docs.speedscale.com/guides/troubleshooting/)
 
-### CI/CD Integrations
+### Integrations and advanced topics
+
 - [CI/CD Integration](https://docs.speedscale.com/guides/integrations/cicd/)
 - [AWS Integration](https://docs.speedscale.com/guides/integrations/aws/)
 - [GCP Integration](https://docs.speedscale.com/guides/integrations/gcp/)
-- [Import](https://docs.speedscale.com/guides/integrations/import/)
-- [Export](https://docs.speedscale.com/guides/integrations/export/)
-
-### Advanced Topics
 - [GraphQL](https://docs.speedscale.com/guides/graphql/)
 - [TLS / Encrypted Traffic](https://docs.speedscale.com/guides/tls/)
 - [WebSockets](https://docs.speedscale.com/guides/websocket/)
-- [Message Brokers (Kafka, RabbitMQ)](https://docs.speedscale.com/guides/message-brokers/)
-- [CLI Reference](https://docs.speedscale.com/guides/cli/)
-- [Troubleshooting](https://docs.speedscale.com/guides/troubleshooting/)
 
-## ProxyMock (Free Local Dev Tool)
+## proxymock (local CLI)
 
-ProxyMock is a free, open-source CLI tool for local API mocking and traffic recording. It captures real API traffic and replays it locally without external dependencies.
+proxymock is the local record/mock/replay CLI for development and CI.
 
-- [ProxyMock Overview](https://docs.speedscale.com/proxymock/)
+- [proxymock Overview](https://docs.speedscale.com/proxymock/)
 - [Installation](https://docs.speedscale.com/proxymock/getting-started/installation/)
 - [Quickstart (CLI)](https://docs.speedscale.com/proxymock/getting-started/quickstart/quickstart-cli/)
 - [Quickstart (MCP)](https://docs.speedscale.com/proxymock/getting-started/quickstart/quickstart-mcp/)
 - [FAQ](https://docs.speedscale.com/proxymock/getting-started/faq/)
 - [Language Reference](https://docs.speedscale.com/proxymock/getting-started/language-reference/)
 - [How It Works](https://docs.speedscale.com/proxymock/how-it-works/)
-- [Guides](https://docs.speedscale.com/proxymock/guides/)
-- [AWS Integration](https://docs.speedscale.com/proxymock/aws/)
 
-## QABot
-
-AI-powered test assistant for Speedscale.
-
-- [QABot](https://docs.speedscale.com/qabot/)
-
-## Reference
-
-Technical reference for configuration, filters, transforms, and eBPF traffic collection.
+## Reference and security
 
 - [Reference](https://docs.speedscale.com/reference/)
 - [Technology Support](https://docs.speedscale.com/reference/technology-support/)
 - [Configuration](https://docs.speedscale.com/reference/configuration/)
 - [Filters](https://docs.speedscale.com/reference/filters/)
 - [eBPF Traffic Collection](https://docs.speedscale.com/reference/ebpf-traffic-collection/)
-
-## Security
-
 - [Security Overview](https://docs.speedscale.com/security/)
 - [Data Protection](https://docs.speedscale.com/security/data_protection/)
 
-## Related Resources
+## Related resources
 
 - [Speedscale Website](https://speedscale.com)
 - [Blog](https://speedscale.com/blog/)

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,6 +1,6 @@
 # Speedscale Documentation
 
-> Documentation for Speedscale, a runtime validation platform for API changes. Speedscale captures real traffic and replays it against new code to catch behavioral regressions before release. This documentation covers Speedscale Platform, proxymock, and supporting workflows.
+> Documentation for Speedscale, a runtime validation platform for API changes. Speedscale captures real traffic and replays it against new code to catch behavioral regressions before release, including Kubernetes collection paths using goproxy and eBPF-based traffic capture. This documentation covers Speedscale Platform, proxymock, and supporting workflows.
 
 ## Product definition
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -73,6 +73,12 @@ proxymock is the local record/mock/replay CLI for development and CI.
 - [Security Overview](https://docs.speedscale.com/security/)
 - [Data Protection](https://docs.speedscale.com/security/data_protection/)
 
+## Security operating models
+
+- **Local recording:** proxymock supports local record/mock/replay workflows where traffic stays local unless explicitly pushed.
+- **BYOC:** Speedscale can run in customer-controlled cloud boundaries for sovereignty and compliance requirements.
+- **DLP:** sensitive fields can be redacted before data leaves the customer network.
+
 ## Related resources
 
 - [Speedscale Website](https://speedscale.com)


### PR DESCRIPTION
## Summary
- rewrite the getting started intro so it states what Speedscale does, who it is for, and why it differs in plain language
- normalize machine-readable docs metadata in `static/llms.txt` and standardize `proxymock` casing
- add a compact AI citation readiness checklist to `README.md` for contributors

## Validation
- yarn build