### PR TITLE
Migrate Vimeo embeds to YouTube

### DIFF
--- a/docs/concepts/capture.md
+++ b/docs/concepts/capture.md
@@ -4,8 +4,7 @@ sidebar_position: 1
 ---
 # Capturing Traffic
 
-<iframe src="https://player.vimeo.com/video/986454551?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/986454551">Bootstrapping Traffic Capture</a> from <a href="https://vimeo.com/speedscale">Speedscale</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/0bdI6vhNavQ?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 Speedscale captures [traffic](/reference/glossary.md#traffic) flowing through your application.
 This includes inbound as well as outbound, and is usually handled by a [proxy sidecar](/reference/glossary.md#proxy) added to your workloads.

--- a/docs/concepts/transforms.md
+++ b/docs/concepts/transforms.md
@@ -5,8 +5,7 @@ sidebar_position: 9
 
 # Transforms
 
-<iframe src="https://player.vimeo.com/video/985860338" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/985860338">Stop scripting and use transforms</a> from <a href="https://vimeo.com/speedscale">Speedscale</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/RojqxxHL7oc?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 Automatically modify traffic before or during a replay.
 

--- a/docs/getting-started/installation/sidecar/install.md
+++ b/docs/getting-started/installation/sidecar/install.md
@@ -25,8 +25,7 @@ Prefer the [eBPF collector](/reference/ebpf-traffic-collection) for Kubernetes t
 :::
 
 
-<iframe src="https://player.vimeo.com/video/986454551?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/986454551">Bootstrapping Traffic Capture</a> from <a href="https://vimeo.com/speedscale">Speedscale</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/0bdI6vhNavQ?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 :::tip
 The [envoy](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/listeners/listeners#tcp) proxy (aka Istio) uses the same architecture to redirect traffic. Your platform or security team may already be familiar with this approach.

--- a/docs/getting-started/installation/sidecar/tls.md
+++ b/docs/getting-started/installation/sidecar/tls.md
@@ -19,8 +19,7 @@ When possible, use the [eBPF collector](/reference/ebpf-traffic-collection) to c
 When using the annotation examples below, be sure to _add_ them to any existing annotations on your workload. It's common to delete existing annotations or add the annotations in the wrong place (like on the pod instead of the deployment) in this step.
 :::
 
-<iframe src="https://player.vimeo.com/video/1035399678?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/1035399678">How Speedscale reads TLS requests</a> from <a href="https://vimeo.com/speedscale">Speedscale</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/CyeBytH_U7A?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 ## TLS Inbound Interception
 

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -7,8 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Tutorial
 
-<iframe src="https://player.vimeo.com/video/984892688?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/984892688">Watch the tutorial walkthrough on Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/DHoZaXWEhws?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 In this guide we're going to use [this repo's](https://github.com/speedscale/demo) example app in the `java` directory to [capture](../concepts/capture.md), [transform](../concepts/transforms.md) and [replay](../concepts/replay.md) traffic with [mocks](../concepts/service_mocking.md).
 
@@ -141,8 +140,7 @@ proxymock cloud push snapshot --in proxymock/recorded-YOUR_TIMESTAMP
 
 ## Analyze
 
-<iframe src="https://player.vimeo.com/video/983558864" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/983558864">Exploring Speedscale Traffic Viewer</a> from <a href="https://vimeo.com/speedscale">Speedscale</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/uxymGbdm_v8?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 After a few minutes you should be able to see your traffic in the [Speedscale dashboard](https://app.speedscale.com). Make sure to select the the same service name that you entered in `speedctl install` from the traffic dropdown. You should be able to see the inbound and outbound calls for this app as shown below.
 

--- a/docs/guides/cmek.md
+++ b/docs/guides/cmek.md
@@ -12,8 +12,7 @@ Customer Managed Encryption Keys (CMEK) allow customers with stringent security 
 
 When CMEK is enabled, Speedscale still maintains the cloud infrastructure including databases, data transport and upgrades. The sole difference is that the customer has the ability to remove access completely at any time. In all other respects the Speedscale cloud service runs as another separate tenant.
 
-<iframe src="https://player.vimeo.com/video/1035382935?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/1035382935">Watch the CMEK overview on Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/odqjHek8w3w?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 # Customer Responsibilities
 

--- a/docs/guides/creating-a-snapshot.md
+++ b/docs/guides/creating-a-snapshot.md
@@ -4,8 +4,7 @@ title: Creating a Snapshot
 description: "Create a snapshot in Speedscale to capture and replay specific traffic, utilizing filters and detailed logs for effective API testing and analysis"
 ---
 
-<iframe src="https://player.vimeo.com/video/983558864" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/983558864">Exploring Speedscale Traffic Viewer</a> from <a href="https://vimeo.com/speedscale">Speedscale</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/uxymGbdm_v8?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 ## Observe Traffic
 

--- a/docs/guides/integrations/import/import-postman.md
+++ b/docs/guides/integrations/import/import-postman.md
@@ -4,7 +4,7 @@ description: "Import Postman collections into Speedscale and replay them in a Ku
 sidebar_position: 5
 ---
 
-<iframe src="https://player.vimeo.com/video/825263285?h=f6d27bc7a9" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/jS01DK7R70E?rel=0&modestbranding=1" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 In this guide we will walk through importing an existing Postman collection and replaying it in a Kubernetes cluster. This guide is most helpful when you are unable to install the Speedscale sidecar for some reason, such as the service being brand new with no traffic.
 

--- a/docs/guides/otel.md
+++ b/docs/guides/otel.md
@@ -27,7 +27,7 @@ A Span ID is a unique identifier that marks a single unit of work within a trace
 
 Speedscale allows you to search for any substring of data, anywhere in your API requests, across all services. You can find any trace ID or span ID using this capability. Here is a video showing how the feature works for general filtering:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/SxZ7DFSM89Y" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/SxZ7DFSM89Y?rel=0&modestbranding=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Here are the steps for filtering for an OpenTelemetry trace:
 1. Create a Notebook from the traffic viewer

--- a/docs/guides/transformation/overview.md
+++ b/docs/guides/transformation/overview.md
@@ -97,7 +97,7 @@ Traffic Transform Templates allow you to save transform configurations from one 
 
 ### How to Use Transform Templates
 
-<iframe src="https://player.vimeo.com/video/1109642612" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/XSN8wG_-RO8?rel=0&modestbranding=1" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 1. **Create a Template**: After configuring transforms in a snapshot that achieve your desired accuracy, save them as a template
 2. **Apply to New Snapshots**: When working with new traffic recordings, select and apply your saved template

--- a/docs/guides/transformation/smart-replace.md
+++ b/docs/guides/transformation/smart-replace.md
@@ -11,8 +11,7 @@ Smart Replace is a powerful tool designed to streamline the process of updating 
 
 In this section we'll work through a use case of replacing each user ID in a snapshot with a new test user ID. This is a common use case when user names or other IDs need to be replaced with test IDs to work in lower environments. Keep in mind that if you need to alter your data in other ways, you can use the [transform](/guides/transformation/overview) system. If you're looking to do things like replacing JWT tokens through your traffic you may want to check out this video instead:
 
-<iframe src="https://player.vimeo.com/video/1117518907?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/1117518907">Watch the Smart Replace walkthrough on Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/sLRPEkzgH1A?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 Now let's get started with the multiple-email replacement use case.
 

--- a/docs/guides/transformation/transforms/smart_replace_recorded.md
+++ b/docs/guides/transformation/transforms/smart_replace_recorded.md
@@ -23,8 +23,7 @@ In all future transactions, Speedscale will replace the recorded value with the 
 - **overwrite** - If false, the key=value mapping will be made permanently. If true, the key=value mapping will be rewritten each time `smart_replace_recorded` is called. This is helpful if you want to rotate values through a CSV continuously. For most use cases, overwrite=false (the default) is desired.
 
 ### Example
-<iframe src="https://player.vimeo.com/video/1117518907?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/1117518907">Watch the Smart Replace walkthrough on Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/sLRPEkzgH1A?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 
 #### Configuration

--- a/docs/proxymock/aws/ses.md
+++ b/docs/proxymock/aws/ses.md
@@ -24,7 +24,7 @@ git clone https://github.com/speedscale/demo && cd demo/go-ses-demo
 Don't worry if you can't use this demo app. Just apply the environment variables to your own AWS SES client app.
 
 <div style={{textAlign: 'center'}}>
-  <iframe src="https://player.vimeo.com/video/1133183871" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/if1yzhHvCXQ?rel=0&modestbranding=1" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Recording AWS SES Traffic {#recording-intro}

--- a/docs/proxymock/guides/grpc.md
+++ b/docs/proxymock/guides/grpc.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 **proxymock** can be used with most gRPC services simply by running your app and recording traffic. Making a new mock is very easy and you can learn more about it in the [create your own mocks](../getting-started/quickstart/quickstart-cli.md#recording) section. A list of known supported technologies can be found [here](../../reference/technology-support.md). However, your API or Database may just work so you should try it out.
 
 Check out this video for a walkthrough of gRPC observability and mocking on the local desktop:
-<iframe src="https://player.vimeo.com/video/1062574345?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/q_bGCCNPLAE?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 :::tip
 The go gRPC SDK treats localhost as a special case. If you need to record locally to a gRPC server residing on your local machine then put in your fully qualified hostname (found by running the `hostname` command in a terminal) instead of `localhost`.

--- a/docs/proxymock/guides/llm-simulation.md
+++ b/docs/proxymock/guides/llm-simulation.md
@@ -9,6 +9,10 @@ import TabItem from '@theme/TabItem';
 
 # Mocking LLM APIs
 
+<div style={{textAlign: 'center'}}>
+  <iframe src="https://www.youtube.com/embed/9RoP7Bp1qnI?rel=0&modestbranding=1" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 If your application calls an LLM provider like OpenAI, Anthropic, or Gemini, every request costs money -- even during development and testing. **proxymock** eliminates that cost by recording real LLM responses once and replaying them locally.
 
 This is useful when you are:

--- a/docs/proxymock/guides/mysql.md
+++ b/docs/proxymock/guides/mysql.md
@@ -24,7 +24,7 @@ git clone https://github.com/speedscale/demo && cd demo/java-auth/server
 Build the java *server* normally using maven and start MySQL on your local machine (instructions in the README). Don't worry if you don't have java installed and can't use this app. Just apply the environment variables to your own MySQL client app.
 
 <div style={{textAlign: 'center'}}>
-  <iframe src="https://player.vimeo.com/video/1121680327" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/ScXVxLfFXe8?rel=0&modestbranding=1" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 

--- a/docs/proxymock/guides/postgres.md
+++ b/docs/proxymock/guides/postgres.md
@@ -24,7 +24,7 @@ git clone https://github.com/speedscale/demo && cd demo/go-postgres
 Start PostgreSQL on your local machine (instructions in the README). Don't worry if you don't have go installed and can't use this app. Just apply the environment variables to your own PostgreSQL client app.
 
 <div style={{textAlign: 'center'}}>
-  <iframe src="https://player.vimeo.com/video/1121659640" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/hNbeoyiTmbs?rel=0&modestbranding=1" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 ## Recording PostgreSQL Traffic {#recording-intro}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -14,8 +14,7 @@ import TabItem from '@theme/TabItem';
 - **Sensitive data controls:** enable [DLP](/guides/dlp/) so sensitive fields are redacted before data leaves your network.
 :::
 
-<iframe src="https://player.vimeo.com/video/984892688?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/984892688">Watch the tutorial walkthrough on Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/DHoZaXWEhws?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 In this guide we're going to use [this repo's](https://github.com/speedscale/demo) example app in the `java` directory to [capture](./concepts/capture.md), [transform](./concepts/transforms.md) and [replay](./concepts/replay.md) traffic with [mocks](./concepts/service_mocking.md).
 
@@ -148,8 +147,7 @@ proxymock cloud push snapshot --in proxymock/recorded-YOUR_TIMESTAMP
 
 ## Analyze
 
-<iframe src="https://player.vimeo.com/video/983558864" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/983558864">Exploring Speedscale Traffic Viewer</a> from <a href="https://vimeo.com/speedscale">Speedscale</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
+<iframe src="https://www.youtube.com/embed/uxymGbdm_v8?rel=0&modestbranding=1" width="640" height="582" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
 
 After a few minutes you should be able to see your traffic in the [Speedscale dashboard](https://app.speedscale.com). Make sure to select the the same service name that you entered in `speedctl install` from the traffic dropdown. You should be able to see the inbound and outbound calls for this app as shown below.
 


### PR DESCRIPTION
Replaces every Vimeo iframe across the docs (16 pages) with the equivalent YouTube embed, using `?rel=0&modestbranding=1` to suppress related-video promos and branding. Also adds those same params to the existing otel.md YouTube embed and adds a new YouTube embed for the proxymock LLM simulation guide.

Motivation: we're consolidating video hosting on YouTube and the Vimeo subscription is lapsing soon, so any remaining Vimeo embeds would break.