### PR TITLE
Exclude Docusaurus scaffolding pages from sitemap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1544,6 +1544,18 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+        sitemap: {
+          // Exclude Docusaurus default scaffolding pages and legacy artifacts
+          // from the sitemap so search engines don't waste crawl budget
+          // on low-value URLs (and so GSC/Bing don't flag them as
+          // soft-404 or thin-content).
+          ignorePatterns: [
+            "/index_old/**",
+            "/markdown-page/**",
+            "/search/**",
+          ],
+          filename: "sitemap.xml",
+        },
       }),
     ],
   ],


### PR DESCRIPTION
## Problem

GSC + Bing have been ingesting `/index_old/`, `/markdown-page/`, and `/search/` from the auto-generated sitemap. These are Docusaurus defaults / legacy artifacts that have no SEO value and risk soft-404 or thin-content flags in search consoles.

Per public audit of the live sitemap (https://docs.speedscale.com/sitemap.xml) on 2026-05-27.

## Solution

Add `sitemap.ignorePatterns` to the preset config so these patterns are omitted from sitemap generation. Pages themselves still build — they're just not advertised to crawlers.

## Verification

Before:
- 287 URLs in sitemap
- 3 garbage entries: `/index_old/`, `/markdown-page/`, `/search/`

After (local build):
- 284 URLs in sitemap
- 0 of those 3 patterns present

```
$ grep -oE 'index_old|markdown-page|/search/' build/sitemap.xml | sort -u
(empty)
```

## Follow-up

Source pages (`src/pages/index_old.js`, `src/pages/markdown-page.md`) can be deleted in a separate cleanup if confirmed dead — keeping this PR minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)