### PR TITLE
Skip analytics on localhost and ignore known non-actionable errors

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1513,7 +1513,8 @@ const config = {
       attributes: {
         type: "text/javascript",
       },
-      innerHTML: `(function(h,o,u,n,d) {
+      innerHTML: `if (window.location.hostname === 'docs.speedscale.com') {
+  (function(h,o,u,n,d) {
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
@@ -1529,8 +1530,21 @@ const config = {
       sessionReplaySampleRate: 0,
       trackBfcacheViews: true,
       defaultPrivacyLevel: 'mask-user-input',
+      beforeSend: function(event) {
+        if (event.type !== 'error' || !event.error) return true;
+        var msg = typeof event.error.message === 'string' ? event.error.message : '';
+        // ChunkLoadError: stale tab loaded an index.html that referenced
+        // chunks rotated by a later deploy. Standard Docusaurus pattern,
+        // not actionable in code.
+        if (msg.indexOf('ChunkLoadError') !== -1 || msg.indexOf('Loading chunk') !== -1) return false;
+        // webpack-dev-server WebSocket errors from localhost — belt &
+        // suspenders with the hostname gate above.
+        if (msg.indexOf('webpack-dev-server') !== -1) return false;
+        return true;
+      },
     });
-  })`,
+  });
+}`,
     },
   ],
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1514,11 +1514,20 @@ const config = {
         type: "text/javascript",
       },
       innerHTML: `if (window.location.hostname === 'docs.speedscale.com') {
+  // Errors we know are not actionable in this codebase, so we drop them
+  // before reporting. Keeps the analytics dashboard focused on real bugs.
+  var ignoredErrors = [
+    /ChunkLoadError/,            // stale tab: a deploy rotated chunk filenames
+    /Loading chunk \\d+ failed/,  // same root cause, different message shape
+    /webpack-dev-server/,        // dev-server WebSocket warnings
+  ];
+
   (function(h,o,u,n,d) {
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM');
+
   window.DD_RUM.onReady(function() {
     window.DD_RUM.init({
       clientToken: 'pub2019c1346c7ab4080cf258cb4d94d3c9',
@@ -1531,16 +1540,9 @@ const config = {
       trackBfcacheViews: true,
       defaultPrivacyLevel: 'mask-user-input',
       beforeSend: function(event) {
-        if (event.type !== 'error' || !event.error) return true;
-        var msg = typeof event.error.message === 'string' ? event.error.message : '';
-        // ChunkLoadError: stale tab loaded an index.html that referenced
-        // chunks rotated by a later deploy. Standard Docusaurus pattern,
-        // not actionable in code.
-        if (msg.indexOf('ChunkLoadError') !== -1 || msg.indexOf('Loading chunk') !== -1) return false;
-        // webpack-dev-server WebSocket errors from localhost — belt &
-        // suspenders with the hostname gate above.
-        if (msg.indexOf('webpack-dev-server') !== -1) return false;
-        return true;
+        if (event.type !== 'error') return true;
+        var msg = (event.error && event.error.message) || '';
+        return !ignoredErrors.some(function(re) { return re.test(msg); });
       },
     });
   });


### PR DESCRIPTION
## What

Two cleanups to the analytics snippet in `docusaurus.config.js`:

1. **Only run on the production hostname.** Running `npm run start` locally was loading the analytics script against `localhost`, mixing dev events into production telemetry.
2. **Ignore a small set of known-not-actionable errors** before reporting:
   - Chunk-load failures from stale browser tabs (deploys rotate webpack chunk filenames; older tabs blow up on the next navigation — nothing we can fix in code).
   - Dev-server WebSocket warnings (belt-and-suspenders with #1).

Real bugs are still reported as before.

## Test plan

- [x] `npm run start` on localhost: no analytics script tag is injected.
- [x] Replayed the predicate against representative messages: the three noise classes are dropped; an arbitrary real error message passes through.