### PR TITLE
Remove retired HubSpot from analytics stack docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,6 @@ The site uses a hierarchical structure organized in `/docs/` with these main sec
 
 When deleting pages, always add redirects to `docusaurus.config.js` to prevent broken links. The site uses:
 - Algolia for search functionality
-- HubSpot integration for lead tracking  
 - Google Tag Manager for analytics
 - Mermaid for diagram rendering
 
@@ -86,7 +85,7 @@ When deleting pages, always add redirects to `docusaurus.config.js` to prevent b
 - **React**: 19.0.0  
 - **Node**: >=18.0 required
 - **Search**: Algolia DocSearch
-- **Analytics**: Google Tag Manager, HubSpot
+- **Analytics**: Google Tag Manager
 
 ## Documentation Improvement Plan
 


### PR DESCRIPTION
## Problem
HubSpot is retired but `AGENTS.md` still lists it under lead tracking and the analytics stack.

## Solution
Drop the two stale HubSpot references (lead-tracking bullet + analytics line). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)