### PR TITLE
Clarify proxymock local activation and fix Linux onboarding gaps

### DIFF
--- a/docs/proxymock/getting-started/installation.md
+++ b/docs/proxymock/getting-started/installation.md
@@ -37,7 +37,7 @@ Install the **proxymock** [MCP](https://modelcontextprotocol.io/) by running `pr
 
 ## After installing
 
-Initialize once before your first recording. Browser sign-in is the default path:
+Initialize once before your first recording. This registers a valid email to activate proxymock and is required even for fully local use; your recorded traffic stays on your machine. Browser sign-in is the default path:
 
 - Run `proxymock init` and use the browser sign-in flow.
 - Use `proxymock init --api-key <your key>` only for CI or other headless environments.

--- a/docs/proxymock/getting-started/installation/_cli_linux.mdx
+++ b/docs/proxymock/getting-started/installation/_cli_linux.mdx
@@ -10,3 +10,17 @@ Optionally, install a [specific version](/reference/release-notes.md) by passing
 sh -c "$(curl -Lfs https://downloads.speedscale.com/proxymock/install-proxymock)" -s v2.3.456
 ```
 
+After installing, confirm the CLI is available:
+
+```shell
+proxymock version
+```
+
+If you see `command not found`, proxymock was installed to `$HOME/.speedscale` but that directory is not yet on your `PATH`. Add it to the current shell:
+
+```shell
+export PATH="$PATH:$HOME/.speedscale"
+```
+
+To make it permanent, add that line to your shell profile (for example `~/.bashrc` or `~/.zshrc`).
+

--- a/docs/proxymock/getting-started/quickstart/quickstart-cli.md
+++ b/docs/proxymock/getting-started/quickstart/quickstart-cli.md
@@ -17,6 +17,7 @@ This guide provides a step-by-step approach to creating a [mock server](/referen
 
 :::tip Security model
 - **Local-first:** proxymock keeps recorded traffic local by default.
+- **One-time activation:** proxymock runs locally, but you register a valid email once via `proxymock init` to activate it. It's free and your traffic stays on your machine.
 - **Optional cloud sync:** push snapshots only when you explicitly choose to.
 - **Enterprise controls:** if your org requires cloud boundary ownership, pair workflows with [BYOC](/guides/byoc/) and use [DLP](/guides/dlp/) for sensitive fields.
 :::
@@ -61,12 +62,14 @@ Select your environment below and all instructions will update accordingly. If y
     Make sure you have:
     - A terminal or command prompt open to run proxymock
     - A separate terminal or command prompt open to run the demo app
+    - [git](https://git-scm.com/downloads) installed
     - [go version 1.23.1](https://go.dev/doc/install) or newer installed
   </TabItem>
   <TabItem value="linux" label="🐧 Linux">
     Make sure you have:
     - A terminal or command prompt open to run proxymock
     - A separate terminal or command prompt open to run the demo app
+    - [git](https://git-scm.com/downloads) installed
     - [go version 1.23.1](https://go.dev/doc/install) or newer installed
   </TabItem>
   <TabItem value="codespaces" label="☁️ Codespaces">
@@ -79,6 +82,7 @@ Select your environment below and all instructions will update accordingly. If y
     Make sure you have:
     - A terminal or command prompt open to run proxymock
     - A separate terminal or command prompt open to run the demo app
+    - [git](https://git-scm.com/downloads) installed
     - [go version 1.23.1](https://go.dev/doc/install) or newer installed
   </TabItem>
 </Tabs>

--- a/docs/proxymock/index.md
+++ b/docs/proxymock/index.md
@@ -65,7 +65,7 @@ Need another OS like Windows or are you having issues? See advanced [installatio
 
 - **MCP inegration** - proxymock makes its tools available via MCP. Check out our YouTube [channel](https://www.youtube.com/@speedscale) for prompt ideas that let your LLM use proxymock to analyze bugs.
 
-If you want to deploy any of these [mocks](/reference/glossary.md#mock) or [tests](/reference/glossary.md#test) in the cloud or CI/CD, you can sign up for a **free** account [here](https://app.speedscale.com/signup).
+proxymock runs entirely on your machine. The first time you run it you'll register a valid email to activate it (via `proxymock init`); it's free and your recorded traffic stays local. If you later want to deploy any of these [mocks](/reference/glossary.md#mock) or [tests](/reference/glossary.md#test) in the cloud or CI/CD, use that same **free** account [here](https://app.speedscale.com/signup).
 
 <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1rem', marginTop: '2rem' }}>
   <QuickstartCard />


### PR DESCRIPTION
Running the proxymock docs end-to-end as a brand-new user in a clean Linux container blocked before recording a single request. These edits close the gaps that caused it.

- **Local + activation clarity:** proxymock is fully local, but it needs a one-time valid-email registration via `proxymock init` to activate. Stated this in the overview, the quickstart Security-model tip, and the installation page. The overview previously implied signup was only for cloud/CI.
- **Linux install dead-end:** added a post-install `proxymock version` check and `$HOME/.speedscale` PATH guidance. The installer doesn't add proxymock to `PATH` on Linux, so a fresh user hits `command not found` with no on-screen help.
- **Missing prerequisite:** added `git` to the quickstart "Before you begin" (Step 3 `git clone`s the demo repo).

Docs only, no code/config. +20/-2 across 4 files.