### PR TITLE
Fix incorrect recording port in proxymock quickstart

### DIFF
--- a/docs/proxymock/getting-started/quickstart/quickstart-cli.md
+++ b/docs/proxymock/getting-started/quickstart/quickstart-cli.md
@@ -162,7 +162,7 @@ If you want the language-specific landing pages after this Go-first quickstart, 
   </TabItem>
 </Tabs>
 
-By running this you will start `proxymock` in recording mode while it runs the app as a child process. Now `proxymock` is now listening on port 4343 for incoming traffic. This traffic will be forwarded to the demo app running at 8080. You'll see first the `proxymock` logs then a line across the screen, then the logs for `outerspace-go`. It should look something like this:
+By running this you will start `proxymock` in recording mode while it runs the app as a child process. Now `proxymock` is listening on port 4143 for incoming traffic, which it forwards to the demo app running on port 8080. (proxymock also records outbound traffic on port 4140.) You'll see first the `proxymock` logs then a line across the screen, then the logs for `outerspace-go`. It should look something like this:
 
 ```shell jsx title="Output"
 $ proxymock record -- go run main.go
@@ -194,7 +194,7 @@ Start a _new_ terminal and run the following command.
     ```
 
     :::note Codespaces Port Forwarding
-    Make sure port 4343 is forwarded in your Codespace. You should see it automatically forwarded in the Ports tab.
+    Make sure port 4143 is forwarded in your Codespace. You should see it automatically forwarded in the Ports tab.
     :::
 
   </TabItem>


### PR DESCRIPTION
The proxymock CLI quickstart stated that recording listens on port 4343, but proxymock actually records inbound traffic on port 4143 (confirmed by `proxymock record` output and the demo's `tests/run_http_tests.sh --recording`, which curls `localhost:4143`).

This corrects both occurrences of 4343 in `quickstart-cli.md` (the Step 3 prose and the Codespaces port-forwarding note), removes a duplicated "now" in the same sentence, and adds the outbound proxy port (4140) for accuracy. Verified locally with `yarn build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)