### PR TITLE
Update browser guide for proxymock

### DIFF
--- a/docs/guides/browser.md
+++ b/docs/guides/browser.md
@@ -1,6 +1,6 @@
 ---
-title: Capture and Replay on Browser
-description: "Set up traffic capture and replay in Firefox using Speedscale by installing Speedctl, configuring TLS certificates, and adjusting proxy settings."
+title: Capture Browser Traffic with proxymock
+description: "Record browser traffic locally with proxymock, inspect the generated RRPair files, and replay those downstream dependencies as browser-ready mocks."
 sidebar_position: 3
 ---
 
@@ -8,170 +8,138 @@ sidebar_position: 3
 
 ### Prerequisites
 
-1. [Speedctl is installed](../getting-started/installation/install/cli.md)
-1. Firefox (or Firefox Developer Edition) required
+1. [proxymock is installed](/proxymock/getting-started/installation/)
+1. proxymock is initialized with `proxymock init`
+1. Firefox or Firefox Developer Edition
 
-### Prepare Environment
+proxymock records traffic locally by default. Browser traffic flows through the outbound proxy on port `4140`, and proxymock writes request / response pair (RRPair) files under the output directory you choose.
 
-Now that you have `speedctl` installed, make sure you have TLS certificates created.
+:::tip
+Use a private Firefox window or a separate Firefox profile for recording. Browsers make background calls to many domains, so a clean session keeps the recording easier to inspect and reuse.
+:::
 
-```
-ls -al ~/.speedscale/certs
-```
+## Prepare TLS Certificates
 
-If you have certificates, great! If you got an error `No such file or directory` then generate the default Speedscale certificates:
+Create the proxymock root certificate if it does not already exist:
 
-```
-speedctl create certs
-```
-
-This writes `tls.crt` and `tls.key` to `~/.speedscale/certs`.
-
-You should be able to see your certs are in the directory:
-
-```
-ls ~/.speedscale/certs
-tls.crt tls.key
+```shell
+proxymock certs
 ```
 
-### Start the Capture Session with CLI
+This creates the local certificate files under `~/.speedscale/certs`. On many desktop environments proxymock can add the certificate to the system trust store automatically, but Firefox uses its own certificate store. Import the proxymock CA into Firefox before recording HTTPS sites.
 
-You can start the capture session using the `speedctl` command. This is a super convenient way to capture traffic locally on your own desktop. Note that this is actually creating 2 listeners, one for inbound traffic to your browser (not used in this case because inbound activity is you clicking around on sites) and one for outbound traffic from your browser to other systems (using port 4140).
+1. Open Firefox settings.
+1. Search for `cert`.
+1. Click **View Certificates**.
+1. Select the **Authorities** tab.
+1. Click **Import**.
+1. Select `~/.speedscale/certs/tls.crt`.
+1. Check **Trust this CA to identify websites**.
 
+![Firefox certificate manager](./browser/firefox-certificate-manager.png)
+
+## Start Recording
+
+Start proxymock in one terminal:
+
+```shell
+proxymock record --out proxymock/browser-recording
 ```
-speedctl capture --proxy-out-port 4140 browser 9999
-```
 
-![speedctl capture](./browser/firefox-speedctl.png)
+Leave this command running. It starts the outbound proxy on `localhost:4140` and writes captured browser traffic to `proxymock/browser-recording`.
 
-### Trust Certificate in Firefox
+## Route Firefox Through proxymock
 
-Now copy the public certificate `tls.crt` to a location where Firefox can read it:
+Configure Firefox to send HTTP and HTTPS requests through the proxymock proxy.
 
-```
-cp ~/.speedscale/certs/tls.crt ~/Documents
-```
-
-1. Open the Settings in Firefox, and go to the Certificates section (it is easy to just search for `cert` and you should find it).
-1. Click the `View Certificates` button.
-1. Select the `Authorities` tab.
-1. Click the `Import` button.
-1. Select the `tls.crt` file from your `Documents` directory.
-1. Check the box that says `Trust this CA to identify websites.`
-
-![Firefox](./browser/firefox-certificate-manager.png)
-
-## Start the Capture Session in Firefox
-
-Now you need to set up Firefox so it will send the traffic to goproxy, this is done by configuring in the proxy settings. First open settings,
-
-1. Open the Settings in Firefox, and go to the Proxy section (it is easy to just search for `proxy` and you should find it).
-1. Select `Manual proxy configuration` radio button.
-1. Put `[localhost](http://localhost)` and port `4140`
-1. Check the box that says `Also use this proxy for HTTPS`
-1. Select `OK` to save your settings.
+1. Open Firefox settings.
+1. Search for `proxy`.
+1. Click **Settings** in the Network Settings section.
+1. Select **Manual proxy configuration**.
+1. Set **HTTP Proxy** to `localhost` and **Port** to `4140`.
+1. Check **Also use this proxy for HTTPS**.
+1. Click **OK**.
 
 ### Clear Browser Cache
 
-Before you start browsing to a site, it’s always a good practice to clear your cache so that your browser makes fresh calls to the backend system.
+Clear the browser cache before browsing so Firefox makes fresh requests through proxymock.
 
-1. Open the Settings in Firefox, and go to the Cookies and Site Data section (it is easy to just search for `cache` and you should find it).
-1. Click the `Clear Data` button.
-1. Make sure both checkboxes are checked.
-1. Click `Clear` to clear cache.
-1. On the warning click `Clear Now` to delete all your cache.
+1. Open Firefox settings.
+1. Search for `cache`.
+1. Click **Clear Data** in the Cookies and Site Data section.
+1. Select both checkboxes.
+1. Click **Clear**.
 
-## Browsing a Site
+## Browse the Site You Want to Capture
 
-Now you’re ready, feel free to browse a site. Within 1-2 minutes, you should see the traffic showing up in Speedscale. You can view your traffic by opening another browser (not Firefox) and navigating to [https://app.speedscale.com](https://app.speedscale.com). Click the Traffic heading in the main navigation and then select your service (browser) from the filters.
+Open the site you want to record and exercise the pages or flows you care about. proxymock writes each captured request and response as an RRPair file under the recording directory.
 
-:::note
-The traffic shows up as outbound because it is leaving your browser and going to another backend system, the important thing is that traffic is showing up at all.
-:::
+When you are done browsing, stop the recorder with `CTRL-C`.
 
-You may be surprised to see how many different systems your browser is accessing. Feel free to add filters to specify the subset of traffic you are really interested in. Once you see the traffic you like then you can create a snapshot by hitting the `Save` button and keeping all the defaults. This will create a snapshot with an ID that you will need in the next steps.
+To inspect the recording in the terminal:
 
-![Snapshot](./browser/snapshot-wikipedia.png)
-
-## Replay Traffic
-
-Now that you have a snapshot, you have 2 options.
-1. **Service Mocks** - You can turn the traffic into service mocks so that you can develop locally on your machine without depending on external systems.
-1. **Test Cases** - You can turn the traffic into test cases that you can drive against the backend system for functional, contract or performance tests.
-
-### Replay Service Mocks
-
-Your snapshot is ready, now you can run `speedctl` in a different mode to mock out the endpoints it was previously capturing. Make sure you end your current capture session with `CTRL-C` first. Then start the replay with the following command:
-
-```
-speedctl replay --mode=mocks-only --http-port 4140 --verbose SNAPSHOT_ID
+```shell
+proxymock inspect --in proxymock/browser-recording
 ```
 
-Now if you refresh your browser or click on the same pages, everything loads as it was before, but you can see the traffic in the logs. Here is an example from our wikipedia use case:
+To inspect it in the local web UI:
 
-```
-2023-07-02 18:16:11 INFO  populating tokenizer  ( configuration:Name:"standard"  Out:{Type:"http_match_request_body"  Filters:{}}  ID:"standard"  protected:true )
-2023-07-02 18:16:11 INFO  started provider  ( name:mongodb )
-2023-07-02 18:16:11 INFO  started provider  ( name:postgres )
-2023-07-02 18:16:11 INFO  started provider  ( name:amqp_091 )
-2023-07-02 18:16:11 INFO  starting HTTP server  ( address::4140 )
-2023-07-02 18:16:11 INFO  starting HTTPS server  ( address::30124 )
-2023-07-02 18:16:14 DEBUG HIT  ( msgNum:1 sig:{"host":"www.wikipedia.org", "method":"GET", "httpVersion":"2.0", "url":"/"} uuid:dB3ADZ/wSMKifIi1/hzmOA== )
+```shell
+proxymock web
 ```
 
-The service mock is providing the responses which lets you develop independently from these downstream systems. If you hit `CTRL-C` on your `speedctl` session you'll see the next page on your browser doesn't work.
+You can also inspect the files directly:
 
-### Replay Test Cases
-
-In order to turn the traffic into test cases you need to "reverse" the outbound calls so they will appear as inbound traffic and can be used for tests. Let's create a new snapshot just for the traffic going to a single site `en.wikipedia.org` which you can do by using a filter. Once you have created that snapshot, then this is the process to turn it into tests:
-
-1. Download the snapshot locally
-1. Reverse the traffic so the outbound traffic become inbound
-1. Upload the snapshot again
-1. Replay it against the backend
-
-```
-speedctl pull snapshot SNAPSHOT_ID
+```shell
+find proxymock/browser-recording -name '*.md' | head
 ```
 
-The snapshot definition as well as all the traffic has now been downloaded to your local machine in the directory `~/.speedscale/data/snapshots`. You want to open the snapshot file itself which is named: `~/.speedscale/data/snapshots/SNAPSHOT_ID.json`. Use your favorite editor such as VSCode or vim or even emacs. You'll want to add this value to the JSON.
+## Run the Browser Against Mocks
 
-```
-"reverseServices": true,
-```
+Start the mock server with the recording you just created:
 
-![snapshot-edit](./browser/snapshot-edit.png)
-
-Make sure to save your changes, and then upload with the following command:
-
-```
-speedctl push snapshot SNAPSHOT_ID
+```shell
+proxymock mock --in proxymock/browser-recording --out proxymock/browser-mock-results
 ```
 
-It will ask you if you're sure `▸ Snapshot already exists, overwrite? [Y/n]: y` (yup you're sure), and then you will see the snapshot changes inside the Speedscale UI. The outbound traffic is gone and now you can see it showing up as inbound.
+Keep Firefox pointed at `localhost:4140` and reload the same pages. Requests that match the recording return local mock responses. Requests that do not match are passed through to the real destination by default and are written under `proxymock/browser-mock-results`.
 
-![snapshot-reversed](./browser/snapshot-reversed.png)
+If you want the browser to fail instead of passing through unrecorded requests, run:
 
-Now you can run the replay with the following command. This uses the 100 replicas snapshot which will take the small number of calls and multiply them into a larger number of requests.
-
-```
-speedctl replay --custom-url en.wikipedia.org --test-config-id performance_100replicas SNAPSHOT_ID
+```shell
+proxymock mock --in proxymock/browser-recording --no-passthrough
 ```
 
-Even running 100 copies of the traffic is actually done fairly quickly (Wikipedia is pretty fast after all), and you'll see a report in the Speedscale UI. You can observe that the calls were each executed 100x as many times as they were recorded. This whole process only took a couple of minutes and much faster than writing a test case with all of these steps.
+This mode is useful for checking whether a flow is fully covered by the recording. Modern web pages often include analytics, ads, fonts, and background polling, so expect to refine the recording if you use `--no-passthrough`.
 
-![report table](./browser/report-table.png)
+## About proxymock Replay
+
+`proxymock replay` sends recorded inbound requests back to an application. A browser-only recording is outbound browser traffic, so the browser workflow above usually uses `proxymock mock` rather than `proxymock replay`.
+
+If you want generated tests for your own application, record the app itself instead:
+
+```shell
+proxymock record -- <your-app-command>
+```
+
+Then exercise the app through the inbound proxy on port `4143`, stop the recorder, and replay those inbound transactions:
+
+```shell
+proxymock replay --test-against http://localhost:8080
+```
+
+See the [proxymock CLI quickstart](/proxymock/getting-started/quickstart/quickstart-cli/) for the full record, mock, and replay loop.
 
 ## Cleaning Up
 
-Once you are finished with your testing, you can simply turn off the proxy settings in Firefox and it will go back to normal.
+When you are finished, turn off manual proxy configuration in Firefox. If you used a temporary Firefox profile, you can delete it after recording.
 
 ## Summary
 
 In this guide you learned how to:
-* Capture traffic from the browser to various sites and backend systems
-* Analyze and filter the data returned
-* Convert this traffic into service mocks and test cases
-* Easily replay the traffic from your own machine
 
-If you thought this was pretty useful, feel free to try it out on some sites of your own, if you have any questions feel free to join us in the [Speedscale Community](https://slack.speedscale.com)!
+- Route Firefox through proxymock
+- Record browser traffic locally as RRPair files
+- Inspect captured browser requests
+- Serve the captured traffic back as local mock responses
+- Use app-side recording when you need `proxymock replay` tests


### PR DESCRIPTION
## Summary
- Replace the old Speedctl/cloud snapshot browser workflow with current proxymock record/mock commands.
- Document Firefox certificate trust and proxy setup for `localhost:4140`.
- Clarify that browser-only captures are used with `proxymock mock`, while `proxymock replay` is for inbound app recordings.

Linear: https://linear.app/speedscale/issue/S-10609/update-proxymock-cli-docs-to-match-current-implementation

## Validation
- `yarn build`

Note: build passes with existing Docusaurus redirect override warnings for `/proxymock/getting-started/quickstart/quickstart-cli/` and `/proxymock/getting-started/quickstart/quickstart-mcp/`.