### PR TITLE
Clarify browser mock cache behavior

### DIFF
--- a/docs/guides/browser.md
+++ b/docs/guides/browser.md
@@ -104,6 +104,8 @@ proxymock mock --in proxymock/browser-recording --out proxymock/browser-mock-res
 
 Keep Firefox pointed at `localhost:4140` and reload the same pages. Requests that match the recording return local mock responses. Requests that do not match are passed through to the real destination by default and are written under `proxymock/browser-mock-results`.
 
+If Firefox serves a page from cache, it may not send a request to proxymock. Use a hard reload or clear browser cache again before validating that the mock is being used. A matched response is written under the mock output directory with `match: "HIT"` in the RRPair metadata.
+
 If you want the browser to fail instead of passing through unrecorded requests, run:
 
 ```shell


### PR DESCRIPTION
## Summary
- add a Firefox cache caveat to the proxymock browser guide
- explain that a cached page may bypass proxymock until hard reload or cache clear
- point readers at the mock output HIT metadata for validation

## Testing
- yarn build
- Firefox Developer Edition end-to-end validation: recorded http://httpbingo.org/cache/0?pm=firefox-dev-e2e-20260626 through proxymock, replayed with proxymock mock --no-passthrough, and confirmed mock output contained match=HIT and responderMatch=HIT

Follow-up to #701, which merged before this Firefox cache note landed.