### PR TITLE
docs: add GKE Autopilot install guide

### DIFF
--- a/docs/getting-started/installation/install/cloudrun.md
+++ b/docs/getting-started/installation/install/cloudrun.md
@@ -22,7 +22,7 @@ In order to capture traffic from Cloud Run, we need to set up a few components s
 
 ### Create a cluster
 
-We need to create a GKE cluster in order to run our proxy and forwarding components. Follow the prompts in the Google Cloud console to create a standard GKE cluster. Do not create an Autopilot cluster. All other standard settings should be fine. Cluster creation can take a few minutes and we need to wait till it's finished in order to deploy Speedscale components to it. Once it's done, setup `kubectl` access by running
+We need to create a GKE cluster in order to run our proxy and forwarding components. Follow the prompts in the Google Cloud console to create a standard GKE cluster. Do not create an Autopilot cluster for this setup — if you specifically need Autopilot, follow the [GKE Autopilot guide](/getting-started/installation/install/gke-autopilot) instead. All other standard settings should be fine. Cluster creation can take a few minutes and we need to wait till it's finished in order to deploy Speedscale components to it. Once it's done, setup `kubectl` access by running
 
 ```
 gcloud container clusters get-credential <cluster-name> --region <region>

--- a/docs/getting-started/installation/install/gke-autopilot.md
+++ b/docs/getting-started/installation/install/gke-autopilot.md
@@ -1,6 +1,6 @@
 ---
 title: GKE Autopilot
-description: Install Speedscale with eBPF traffic capture on a GKE Autopilot cluster using a customer-owned WorkloadAllowlist. Covers the Google Cloud support request, org policy, AllowlistSynchronizer, and the Autopilot-specific Helm values required to pass Warden admission.
+description: The complete guide to running Speedscale on GKE Autopilot. Covers both capture paths — eBPF via a customer-owned WorkloadAllowlist (support request, org policy, AllowlistSynchronizer) and sidecar dual proxy mode — plus the Autopilot-specific Helm values required to pass Warden admission.
 sidebar_position: 12
 ---
 
@@ -12,9 +12,14 @@ This workflow is currently in preview status. Please provide feedback in our [Sl
 
 [GKE Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) is Google's fully managed mode for GKE. Autopilot blocks privileged workloads by default through its Warden admission controller. The Speedscale eBPF capture agent (`nettap`) needs Linux capabilities, host namespace access, and a few `hostPath` mounts that Warden rejects unless the workload is explicitly allowed.
 
-This guide uses a **customer-owned [WorkloadAllowlist](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-privileged-allowlists)** to approve the Speedscale agent on your project. This path is needed until the Speedscale Autopilot partner allowlist is published globally.
+## Capture Options on Autopilot
 
-Expected timeline is about one week. Most of that is waiting for Google Cloud support to enable customer-owned WorkloadAllowlists on your project.
+Autopilot's restrictions affect how Speedscale captures traffic. There are two supported approaches — pick one:
+
+- **eBPF capture** (the main path on this page). A privileged `nettap` DaemonSet captures traffic for whole namespaces. It needs a **customer-owned [WorkloadAllowlist](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-privileged-allowlists)** to admit the privileged pods, which requires a one-time Google Cloud eligibility request (about one week of lead time). Best for broad, low-touch capture across many workloads. This path is needed until the Speedscale Autopilot partner allowlist is published globally.
+- **[Sidecar capture (dual proxy mode)](#sidecar-capture-dual-proxy-mode)**. A per-workload sidecar proxy — no privileged DaemonSet and no WorkloadAllowlist, so no eligibility request. Autopilot forbids the sidecar's transparent proxy, so you run it in `dual` proxy mode and point your app's outbound traffic at it. Best when you only need a few workloads and want to skip the eligibility step.
+
+The rest of this page walks through the eBPF path. Jump to [Sidecar Capture](#sidecar-capture-dual-proxy-mode) for the sidecar alternative.
 
 ## Prerequisites
 
@@ -278,6 +283,60 @@ On Autopilot, the operator's Java Agent init container can be rejected if the in
 | Replay init containers rejected by Warden | Missing `ephemeral-storage` values | Reinstall with the `sidecar.resources.*.ephemeral-storage=100Mi` values |
 | Nettap image digest mismatch after a chart upgrade | Installed chart version does not match the allowlist | Install the chart `--version` that matches your `workload-allowlist.yaml`, or upload the updated allowlist from Speedscale |
 | Forwarder crashes with `FATAL: failed to get filter rule` | `filterRule=none` in the configmap | Patch it: `kubectl patch cm speedscale-forwarder -n speedscale --type merge -p '{"data":{"SPEEDSCALE_FILTER_RULE":"standard"}}'` |
+
+## Sidecar Capture (Dual Proxy Mode)
+
+If you do not want to run the privileged eBPF DaemonSet (or want to avoid the WorkloadAllowlist eligibility request), you can capture per workload with the Speedscale sidecar instead. Autopilot does not allow the sidecar to make the networking changes a transparent proxy needs, so the sidecar must run in `dual` proxy mode, and your application must send its own outbound traffic to the sidecar's forward proxy.
+
+`transparent` proxy mode is **not** supported on Autopilot. See [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md) for how dual mode works.
+
+### Operator values
+
+Autopilot also blocks the sidecar's smart reverse DNS (it needs `NET_ADMIN`), and it enforces that every container's resource requests equal its limits, including `ephemeral-storage`. Set these operator values when you [install the operator](./kubernetes-operator.md):
+
+```yaml
+disableSidecarSmartReverseDNS: true
+
+sidecar:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+      ephemeral-storage: 100Mi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+      ephemeral-storage: 100Mi
+```
+
+See the [Helm reference](/reference/helm.md) for `disableSidecarSmartReverseDNS`.
+
+### Workload annotations
+
+Inject the sidecar in dual mode with matching request/limit annotations:
+
+```yaml
+sidecar.speedscale.com/inject: "true"
+sidecar.speedscale.com/proxy-type: "dual"
+sidecar.speedscale.com/proxy-protocol: "tcp:http"
+sidecar.speedscale.com/proxy-port: "8080"
+sidecar.speedscale.com/cpu-request: 500m
+sidecar.speedscale.com/cpu-limit: 500m
+sidecar.speedscale.com/memory-request: 1Gi
+sidecar.speedscale.com/memory-limit: 1Gi
+sidecar.speedscale.com/ephemeral-storage-request: 100Mi
+sidecar.speedscale.com/ephemeral-storage-limit: 100Mi
+```
+
+### Configure the application
+
+Dual mode does not reconfigure your runtime — the app must route outbound traffic to the sidecar's forward proxy on `127.0.0.1:4140` (unless you changed `proxy-out-port`):
+
+- **Java:** add `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, and `-Dhttps.proxyPort` via `JAVA_TOOL_OPTIONS`. If you enable `tls-out`, add the truststore flags from the [Java reference](/reference/languages/java.md).
+- **Runtimes that honor proxy env vars:** set `HTTP_PROXY` and `HTTPS_PROXY` to `http://127.0.0.1:4140`.
+- **Clients with custom proxy behavior:** configure the library directly so outbound traffic actually uses the sidecar.
+
+See [TLS Support](/getting-started/installation/sidecar/tls.md) for outbound TLS decryption details.
 
 ## Getting Help
 

--- a/docs/getting-started/installation/install/gke-autopilot.md
+++ b/docs/getting-started/installation/install/gke-autopilot.md
@@ -1,0 +1,284 @@
+---
+title: GKE Autopilot
+description: Install Speedscale with eBPF traffic capture on a GKE Autopilot cluster using a customer-owned WorkloadAllowlist. Covers the Google Cloud support request, org policy, AllowlistSynchronizer, and the Autopilot-specific Helm values required to pass Warden admission.
+sidebar_position: 12
+---
+
+# Working with GKE Autopilot
+
+:::caution
+This workflow is currently in preview status. Please provide feedback in our [Slack community](https://slack.speedscale.com).
+:::
+
+[GKE Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) is Google's fully managed mode for GKE. Autopilot blocks privileged workloads by default through its Warden admission controller. The Speedscale eBPF capture agent (`nettap`) needs Linux capabilities, host namespace access, and a few `hostPath` mounts that Warden rejects unless the workload is explicitly allowed.
+
+This guide uses a **customer-owned [WorkloadAllowlist](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-privileged-allowlists)** to approve the Speedscale agent on your project. This path is needed until the Speedscale Autopilot partner allowlist is published globally.
+
+Expected timeline is about one week. Most of that is waiting for Google Cloud support to enable customer-owned WorkloadAllowlists on your project.
+
+## Prerequisites
+
+- A GCP project with billing enabled.
+- A GCP **Organization** with a paid Customer Care tier (Standard or higher). Google requires an Organization resource to purchase any paid support tier, and you need a support case to request WorkloadAllowlist eligibility. A standalone billing account with no Organization (for example a personal account) cannot buy support and cannot complete Step 1.
+- Permission to set project org policies.
+- `gcloud`, `kubectl`, and `helm`.
+- A Speedscale API key.
+- Two files from Speedscale support, matched to a specific operator chart version:
+  - `workload-allowlist.yaml`
+  - `allowlist-synchronizer.yaml`
+
+Contact [Speedscale support](https://slack.speedscale.com) to get the allowlist files. The `workload-allowlist.yaml` pins exact container image SHA-256 digests, so it is tied to one operator chart version. Install that exact chart version (see [Step 6](#6-install-speedscale-with-ebpf)).
+
+Set these variables for the commands below:
+
+```bash
+export PROJECT_ID="YOUR_PROJECT_ID"
+export REGION="us-central1"
+export CLUSTER_NAME="YOUR_CLUSTER_NAME"
+export BUCKET_NAME="${PROJECT_ID}-speedscale-autopilot-allowlists"
+export SPEEDSCALE_API_KEY="YOUR_SPEEDSCALE_API_KEY"
+export CHART_VERSION="VERSION_MATCHED_TO_YOUR_ALLOWLIST"
+```
+
+Enable the required APIs:
+
+```bash
+gcloud services enable \
+  container.googleapis.com \
+  storage.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  orgpolicy.googleapis.com \
+  serviceusage.googleapis.com \
+  --project "${PROJECT_ID}"
+```
+
+## 1. Request WorkloadAllowlist Eligibility
+
+Create a Google Cloud support case.
+
+- **Category:** GKE / Autopilot
+- **Priority:** P3
+- **Subject:** `Grant WorkloadAllowlist eligibility for project PROJECT_ID`
+
+Description:
+
+```text
+We need to run Speedscale's eBPF-based traffic capture agent, nettap, as a
+privileged DaemonSet on GKE Autopilot. The agent requires capabilities BPF,
+PERFMON, NET_ADMIN, SYS_ADMIN, SYS_PTRACE, and SYS_RESOURCE, plus hostNetwork,
+hostPID, and hostPath mounts for /proc, /sys, and /var/run/netns.
+
+We are requesting eligibility to use customer-owned WorkloadAllowlists.
+
+Speedscale is a GCP partner currently in the Autopilot Partner Allowlist review
+process. This customer-owned path is needed until the partner allowlist is
+published globally.
+
+Project ID: PROJECT_ID
+Cluster: CLUSTER_NAME
+Region: REGION
+```
+
+Stop here until Google confirms the project is eligible for customer-owned WorkloadAllowlists. This usually takes 3 to 7 business days.
+
+## 2. Upload the Speedscale Allowlist
+
+After Google approves the project, create a bucket and upload the allowlist:
+
+```bash
+gcloud storage buckets create "gs://${BUCKET_NAME}" \
+  --project "${PROJECT_ID}" \
+  --location "${REGION}"
+
+gcloud storage cp workload-allowlist.yaml \
+  "gs://${BUCKET_NAME}/nettap/workload-allowlist.yaml"
+```
+
+Grant the GKE service agent read access:
+
+```bash
+export PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')"
+export GKE_SERVICE_AGENT="service-${PROJECT_NUMBER}@container-engine-robot.iam.gserviceaccount.com"
+
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET_NAME}" \
+  --member="serviceAccount:${GKE_SERVICE_AGENT}" \
+  --role="roles/storage.objectViewer"
+
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET_NAME}" \
+  --member="serviceAccount:${GKE_SERVICE_AGENT}" \
+  --role="roles/storage.bucketViewer"
+```
+
+The service account must use `container-engine-robot.iam.gserviceaccount.com`.
+
+## 3. Allow the Bucket Path
+
+Set the `container.managed.autopilotPrivilegedAdmission` org policy at the project level. Keep `allowAnyGKEPath: true` to preserve the default GKE-approved allowlists while adding the Speedscale bucket path.
+
+```bash
+cat > /tmp/speedscale-autopilot-policy.yaml <<EOF
+name: projects/${PROJECT_ID}/policies/container.managed.autopilotPrivilegedAdmission
+spec:
+  rules:
+  - enforce: true
+    parameters:
+      allowAnyGKEPath: true
+      allowPaths:
+      - gs://${BUCKET_NAME}/*
+EOF
+
+gcloud org-policies set-policy /tmp/speedscale-autopilot-policy.yaml \
+  --update-mask=spec
+```
+
+Wait about 15 minutes before creating or updating the cluster.
+
+## 4. Create or Update the Autopilot Cluster
+
+For a new cluster:
+
+```bash
+gcloud container clusters create-auto "${CLUSTER_NAME}" \
+  --project "${PROJECT_ID}" \
+  --region "${REGION}" \
+  --release-channel rapid \
+  --autopilot-privileged-admission="gke://*,gs://${BUCKET_NAME}/*"
+```
+
+For an existing cluster:
+
+```bash
+gcloud container clusters update "${CLUSTER_NAME}" \
+  --project "${PROJECT_ID}" \
+  --region "${REGION}" \
+  --autopilot-privileged-admission="gke://*,gs://${BUCKET_NAME}/*"
+```
+
+The `gke://*` entry keeps the default GKE-approved allowlist source enabled. The `gs://${BUCKET_NAME}/*` entry adds your Speedscale allowlist source.
+
+Connect `kubectl`:
+
+```bash
+gcloud container clusters get-credentials "${CLUSTER_NAME}" \
+  --project "${PROJECT_ID}" \
+  --region "${REGION}"
+```
+
+## 5. Install the AllowlistSynchronizer
+
+Create a cluster-specific copy of the synchronizer file and apply it:
+
+```bash
+sed \
+  -e "s/YOUR_PROJECT_NUMBER/${PROJECT_NUMBER}/g" \
+  -e "s/YOUR_BUCKET_NAME/${BUCKET_NAME}/g" \
+  allowlist-synchronizer.yaml > /tmp/speedscale-allowlist-synchronizer.yaml
+
+kubectl apply -f /tmp/speedscale-allowlist-synchronizer.yaml
+kubectl wait --for=condition=Ready allowlistsynchronizer/speedscale-nettap-sync --timeout=60s
+```
+
+Verify the synchronizer and allowlist were created:
+
+```bash
+kubectl get allowlistsynchronizer speedscale-nettap-sync -o yaml
+kubectl get workloadallowlist speedscale-nettap -o yaml
+```
+
+If the synchronizer is not Ready, inspect `status.conditions[*].message` and `status.managedAllowlistStatus[*].lastError`.
+
+## 6. Install Speedscale With eBPF
+
+Add the Speedscale Helm repo and [install the operator](./kubernetes-operator.md) with eBPF enabled.
+
+:::caution Pin the chart version
+Install the chart version that matches your `workload-allowlist.yaml`. The allowlist pins exact image SHA-256 digests; a different chart version pulls different `nettap`/`goproxy` images whose digests will not match, and Warden will reject the nettap pods. To move to a newer version, get a re-pinned `workload-allowlist.yaml` from Speedscale first.
+:::
+
+```bash
+helm repo add speedscale https://speedscale.github.io/operator-helm/
+helm repo update
+
+helm upgrade --install speedscale-operator speedscale/speedscale-operator \
+  --version "${CHART_VERSION}" \
+  --namespace speedscale --create-namespace \
+  --set apiKey="${SPEEDSCALE_API_KEY}" \
+  --set clusterName="${CLUSTER_NAME}" \
+  --set image.registry=gcr.io/speedscale \
+  --set ebpf.enabled=true \
+  --set 'sidecar.resources.limits.cpu=500m' \
+  --set 'sidecar.resources.limits.memory=512Mi' \
+  --set 'sidecar.resources.limits.ephemeral-storage=100Mi' \
+  --set 'sidecar.resources.requests.cpu=500m' \
+  --set 'sidecar.resources.requests.memory=512Mi' \
+  --set 'sidecar.resources.requests.ephemeral-storage=100Mi'
+```
+
+Autopilot requires that resource requests and limits match, and that every container declares `ephemeral-storage`. The `ephemeral-storage` values are required for Speedscale replay init containers to pass Warden admission.
+
+Verify the install:
+
+```bash
+kubectl get pods -n speedscale
+kubectl get pods -n speedscale -l app=speedscale-nettap
+```
+
+The nettap pod should show `2/2 Running` on each node.
+
+## 7. Configure a Capture Target
+
+Set the namespace and app label for the workload you want to capture, then add it as an eBPF capture target:
+
+```bash
+export APP_NAMESPACE="YOUR_APP_NAMESPACE"
+export APP_NAME="YOUR_APP_LABEL"
+
+helm upgrade speedscale-operator speedscale/speedscale-operator \
+  --version "${CHART_VERSION}" \
+  --namespace speedscale --reuse-values \
+  --set "ebpf.configuration.capture.targets[0].name=${APP_NAME}" \
+  --set "ebpf.configuration.capture.targets[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name=${APP_NAMESPACE}" \
+  --set "ebpf.configuration.capture.targets[0].podSelector.matchLabels.app=${APP_NAME}"
+```
+
+`--reuse-values` preserves your install values but not the chart version, so pin `--version` again here. Generate traffic against the workload, then confirm it appears in Speedscale.
+
+## Updating Speedscale Versions
+
+The WorkloadAllowlist pins container image digests, so it must be updated in lockstep with the chart. When Speedscale provides an updated `workload-allowlist.yaml` (and its matching chart version), upload it to the same bucket path:
+
+```bash
+gcloud storage cp workload-allowlist.yaml \
+  "gs://${BUCKET_NAME}/nettap/workload-allowlist.yaml"
+```
+
+Force a sync:
+
+```bash
+kubectl annotate allowlistsynchronizer speedscale-nettap-sync \
+  force-sync="$(date +%s)" --overwrite
+```
+
+Then upgrade the chart to the matching `--version`.
+
+## Java Agent Notes
+
+For workloads that make outbound HTTPS calls, the Speedscale [Java Agent](../../../reference/languages/java.md) instruments `SSLSocketImpl` and `SSLEngineImpl` to decrypt TLS traffic.
+
+On Autopilot, the operator's Java Agent init container can be rejected if the injected container does not declare explicit `ephemeral-storage` resources. Speedscale support can provide a workload-specific patch when outbound HTTPS capture is required. If you manually patch a deployment for the Java Agent, re-apply the patch after each replay, since replay cleanup restores the target deployment to its pre-replay state.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Pods rejected by `autopilot-allowlist-synchronizer-limitation` | Google has not enabled customer-owned WorkloadAllowlists on the project | Wait for support approval (Step 1), then retry |
+| Cluster create/update fails with `Cluster is not authorized to use custom allowlist paths` | Project eligibility missing, or the org policy has not propagated | Confirm support approval, verify the org policy, wait 15 minutes, retry |
+| AllowlistSynchronizer not Ready | Bucket IAM, path mismatch, invalid YAML, or incompatible GKE version | Confirm `container-engine-robot` has `objectViewer` and `bucketViewer`, then inspect synchronizer status |
+| Nettap pods rejected by Warden | Resource requests and limits do not match | Reinstall with matching requests and limits |
+| Replay init containers rejected by Warden | Missing `ephemeral-storage` values | Reinstall with the `sidecar.resources.*.ephemeral-storage=100Mi` values |
+| Nettap image digest mismatch after a chart upgrade | Installed chart version does not match the allowlist | Install the chart `--version` that matches your `workload-allowlist.yaml`, or upload the updated allowlist from Speedscale |
+| Forwarder crashes with `FATAL: failed to get filter rule` | `filterRule=none` in the configmap | Patch it: `kubectl patch cm speedscale-forwarder -n speedscale --type merge -p '{"data":{"SPEEDSCALE_FILTER_RULE":"standard"}}'` |
+
+## Getting Help
+
+If you are experiencing issues with this guide and have further questions, please reach out to us on the [community Slack](https://slack.speedscale.com).

--- a/docs/guides/integrations/gcp.md
+++ b/docs/guides/integrations/gcp.md
@@ -14,75 +14,8 @@ The Speedscale operator is compatible with GCP GKE (Google Kubernetes Engine) Au
 
 ### GKE Autopilot
 
-Autopilot is an operational mode for GKE in which the entire cluster configuration, nodes, scaling, etc. are
-all managed by Google. Because it functions more as a managed service, Google also applies strict security
-policies for deployed applications. Most notably, Autopilot does not allow pods with privileged containers.
-Because of this, the Speedscale sidecar is unable to make the necessary networking changes needed to function
-as a transparent proxy. Applications running in GKE Autopilot must configure the [proxy mode](/getting-started/installation/sidecar/proxy-modes.md)
-of the sidecar to operate as a standard forward and reverse proxy (i.e. the "dual" proxy operation mode).
+Autopilot is an operational mode for GKE in which the entire cluster configuration, nodes, scaling, etc. are all managed by Google. It applies strict security policies — most notably, it does not allow pods with privileged containers — which changes how Speedscale captures traffic.
 
-`transparent` proxy mode is not supported in GKE Autopilot.
+Speedscale supports two capture paths on Autopilot: **eBPF** (via a customer-owned WorkloadAllowlist) and a **sidecar in dual proxy mode** (transparent proxy is not supported). Both, along with the required Autopilot Helm values and per-workload annotations, are documented on the single dedicated page:
 
-Autopilot also blocks the sidecar's smart reverse DNS behavior because it requires the `NET_ADMIN`
-capability. When installing the Speedscale operator with Helm, set
-`disableSidecarSmartReverseDNS: true` in your operator values. See the [Helm reference](/reference/helm.md)
-for details.
-
-`dual` mode changes how the sidecar operates, but it does not reconfigure your application runtime to send
-outbound requests to the sidecar's forward proxy. Your workload must still use runtime-specific proxy
-settings such as `HTTP_PROXY` and `HTTPS_PROXY` or Java `JAVA_TOOL_OPTIONS` flags. See
-[Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md), [TLS Support](/getting-started/installation/sidecar/tls.md),
-and the [Java reference](/reference/languages/java.md) for the combined in-cluster Java example.
-
-In addition to this limitation, Autopilot also enforces rules for container resource requests and limits.
-Without any resource requests or limits set for a container, Autopilot will apply a default value. However,
-for those that do specify resources, the value for both the request and the limit must be the same. Without
-additional configuration, the Speedscale operator will configure injected sidecars with default resource
-settings for CPU and memory in order to ensure that clusters utilitizing horizontal pod autoscaling work as
-designed. Ephemeral storage requests/limits must also be specified. Additional workload annotations are necessary to ensure that these values are equivalent.
-
-A complete example of the operator-level settings necessary for GKE Autopilot may look like the following in
-the Helm `values.yaml`:
-
-```
-disableSidecarSmartReverseDNS: true
-
-sidecar:
-  resources:
-    limits:
-      cpu: 500m
-      memory: 512Mi
-      ephemeral-storage: 100Mi
-    requests:
-      cpu: 500m
-      memory: 512Mi
-      ephemeral-storage: 100Mi
-```
-
-Then configure the workload for inline proxy mode with annotations such as:
-
-```
-sidecar.speedscale.com/inject: "true"
-sidecar.speedscale.com/proxy-type: "dual"
-sidecar.speedscale.com/proxy-protocol: "tcp:http"
-sidecar.speedscale.com/proxy-port: "8080"
-sidecar.speedscale.com/cpu-request: 500m
-sidecar.speedscale.com/cpu-limit: 500m
-sidecar.speedscale.com/memory-request: 1Gi
-sidecar.speedscale.com/memory-limit: 1Gi
-sidecar.speedscale.com/ephemeral-storage-request: 100Mi
-sidecar.speedscale.com/ephemeral-storage-limit: 100Mi
-```
-
-### What You Must Still Configure In The App
-
-After the sidecar is injected, the application runtime must still send outbound traffic to the sidecar's
-forward proxy on `127.0.0.1:4140` unless you changed `proxy-out-port`.
-
-- Java: add `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, and `-Dhttps.proxyPort` in
-  `JAVA_TOOL_OPTIONS`. If you also enable `tls-out`, add the truststore flags documented on the
-  [Java reference](/reference/languages/java.md).
-- Languages that honor proxy environment variables: set `HTTP_PROXY` and `HTTPS_PROXY` to
-  `http://127.0.0.1:4140`.
-- Languages or client libraries with custom proxy behavior: configure the library directly so outbound
-  traffic actually uses the sidecar.
+➡️ **[GKE Autopilot install guide](/getting-started/installation/install/gke-autopilot)**

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -13,7 +13,7 @@ Java is fully supported by Speedscale. Use this page for Java-specific proxy set
 - Support matrix: [Technology Support](/reference/technology-support)
 - Shared proxymock proxy reference: [Language Configuration](/proxymock/getting-started/language-reference)
 - Shared sidecar docs: [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md) and [TLS Support](/getting-started/installation/sidecar/tls.md)
-- GKE Autopilot guidance: [GCP](/guides/integrations/gcp.md)
+- GKE Autopilot guidance: [GKE Autopilot](/getting-started/installation/install/gke-autopilot)
 
 ## Choose Your Java Capture Mode
 
@@ -84,7 +84,7 @@ Use dual sidecar mode only when transparent proxy is unavailable. This is not th
 
 Common examples:
 
-- GKE Autopilot
+- [GKE Autopilot](/getting-started/installation/install/gke-autopilot)
 - platforms that block the networking changes required for transparent proxy
 - workloads with other environment-specific restrictions called out in [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md)
 

--- a/docs/reference/technology-support.md
+++ b/docs/reference/technology-support.md
@@ -130,7 +130,7 @@ Most modern enterpise environments are supported by Speedscale and new ones are 
 | DigitalOcean Kubernetes                        |                                                                                         |
 | Docker Desktop                                 | See [guide](../getting-started/installation/install/docker.md)                                                 |
 | DigitalOcean Managed Kubernetes                |                                                                                         |
-| GCP GKE Autopilot                              | Requires [Dual Proxy](/getting-started/installation/sidecar/proxy-modes)                                    |
+| GCP GKE Autopilot                              | See [GKE Autopilot guide](/getting-started/installation/install/gke-autopilot) (eBPF or dual proxy)         |
 | GCP GKE CloudRun                               |                                                                                         |
 | GCP GKE Standard                               |                                                                                         |
 | Istio                                          | See [guide](../getting-started/installation/install/istio.md)                                                  |


### PR DESCRIPTION
## Problem

GKE Autopilot blocks privileged workloads, so capturing traffic there needs platform-specific setup. That guidance was missing for the eBPF/WorkloadAllowlist path and scattered for the sidecar path — the GCP integration page, the Java reference, and the support matrix each described a slice of it, with no single canonical page.

## Solution

Add a canonical **GKE Autopilot** install page under **Installation → More Environments** and point every other reference at it.

The page covers **both** capture paths with a chooser at the top:
- **eBPF capture** — customer-owned WorkloadAllowlist: Google Cloud eligibility request, GCS bucket + `container-engine-robot` IAM, the `container.managed.autopilotPrivilegedAdmission` org policy, AllowlistSynchronizer, operator install with eBPF, plus a troubleshooting table.
- **Sidecar capture (dual proxy mode)** — folded in from the GCP page: `disableSidecarSmartReverseDNS`, matching requests/limits + `ephemeral-storage`, dual-mode annotations, and the app-side proxy config.

Two correctness points baked in from validation:
- **Prerequisite is a GCP _Organization_ with a paid support tier**, not just 'Standard Support on a billing account' — a no-org/personal account can't buy support and can't file the eligibility case.
- **The Helm install pins `--version`** to match the digest-pinned allowlist; an unpinned install pulls mismatched images and Warden rejects the nettap pods.

Consolidation / navigation:
- `guides/integrations/gcp.md` — Autopilot section trimmed to a summary + link (no more duplicated dual-proxy block).
- `reference/technology-support.md` — matrix row now links to the canonical page.
- `reference/languages/java.md` — guidance link and dual-sidecar example point to the canonical page.
- `getting-started/installation/install/cloudrun.md` — Autopilot mention now links over.

The installation sidebar is autogenerated on `main`, so the page registers via `sidebar_position` with no `sidebars.js` change.

## Verification

`yarn build` passes clean against `main` (Docusaurus throws on broken internal links). Confirmed in the generated HTML: the page renders at `/getting-started/installation/install/gke-autopilot`, the `#sidecar-capture-dual-proxy-mode` anchor target exists, both capture sections are present, and the inbound links from gcp/java/technology-support/cloudrun resolve.