### PR TITLE
proxymock docs: move certs/clean under admin, note hidden commands

### DIFF
--- a/docs/getting-started/installation/sidecar/_language_specific_tls_config.mdx
+++ b/docs/getting-started/installation/sidecar/_language_specific_tls_config.mdx
@@ -49,7 +49,7 @@ Java applications utilize a truststore to specify certificates to be trusted.
 Create the keystore with Speedscale certs.
 
 ```shell
-proxymock certs --jks
+proxymock admin certs --jks
 ```
 
 Then apply these flags when running your app:

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -101,7 +101,7 @@ This should start generating traffic that you can see in the Speedscale UI withi
 1. Generate local certs by running the following command (it should say "Certificate was added to keystore"):
 
 ```bash
-proxymock certs --jks
+proxymock admin certs --jks
 ```
 
 2. Start the capture system with this command:

--- a/docs/guides/browser.md
+++ b/docs/guides/browser.md
@@ -23,7 +23,7 @@ Use a private Firefox window or a separate Firefox profile for recording. Browse
 Create the proxymock root certificate if it does not already exist:
 
 ```shell
-proxymock certs
+proxymock admin certs
 ```
 
 This creates the local certificate files under `~/.speedscale/certs`. On many desktop environments proxymock can add the certificate to the system trust store automatically, but Firefox uses its own certificate store. Import the proxymock CA into Firefox before recording HTTPS sites.

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -122,7 +122,7 @@ container `env`, but that should be treated as a fallback.
 
 ## TLS Trust {#tls-trust}
 
-Java typically needs an explicit truststore when TLS interception is involved. See the shared [Language Configuration](/proxymock/getting-started/language-reference#tls-trust) page for the exact `proxymock certs --jks` command, JVM flags, and custom truststore workflow.
+Java typically needs an explicit truststore when TLS interception is involved. See the shared [Language Configuration](/proxymock/getting-started/language-reference#tls-trust) page for the exact `proxymock admin certs --jks` command, JVM flags, and custom truststore workflow.
 
 How that trust is configured depends on the capture mode:
 

--- a/docs/reference/proxymock-cli-reference.md
+++ b/docs/reference/proxymock-cli-reference.md
@@ -22,7 +22,7 @@ proxymock [command]
 
 ## Top-level commands
 
-- `certs` - Create proxymock TLS certificates
+- `admin` - Administrative and maintenance commands (certs, clean)
 - `cloud` - Manage your Speedscale Cloud resources
 - `completion` - Generate the autocompletion script for the specified shell
 - `files` - Utilities for working with RRPair files
@@ -525,26 +525,73 @@ proxymock cloud push [command]
 
 ## System commands
 
-### `certs`
+### `admin`
+
+Administrative and maintenance commands. Groups the low-traffic `certs` and `clean` commands under one noun so they stay out of the main `proxymock --help` list.
+
+**Usage**
+
+```bash
+proxymock admin [command]
+```
+
+**Available subcommands**
+
+- `certs` - Create proxymock TLS certificates
+- `clean` - Remove regenerable proxymock directories (replay/mock output and scratch)
+
+> The legacy top-level paths `proxymock certs` and `proxymock clean` still work as hidden aliases for one or two releases, but `proxymock admin certs` / `proxymock admin clean` are the supported paths.
+
+### `admin certs`
 
 Create proxymock TLS certificates.
 
 **Usage**
 
 ```bash
-proxymock certs [flags]
+proxymock admin certs [flags]
 ```
 
 **Examples**
 
 ```bash
-proxymock certs
+proxymock admin certs
 ```
 
 **Flags**
 
 - `--force` - Regenerate certificates and overwrite the current ones if they exist
 - `--jks` - Create a Java truststore file that includes proxymock certificates
+
+### `admin clean`
+
+Remove regenerable proxymock directories (replay and mock output, and transient replay scratch). Recordings and transform configuration are never touched.
+
+**Usage**
+
+```bash
+proxymock admin clean [flags]
+```
+
+**Examples**
+
+```bash
+# preview what would be removed from ./proxymock
+proxymock admin clean --dry-run
+
+# clean a specific workspace without the confirmation prompt
+proxymock admin clean --in ./proxymock --yes
+
+# also clear the .proxymock/ web-UI state directory
+proxymock admin clean --cache
+```
+
+**Flags**
+
+- `--cache` - Also remove the `.proxymock/` web-UI state directory (backups, dismissed hints, replay configs)
+- `--dry-run` - Show what would be removed without deleting anything
+- `--in string` - Workspace directory to clean (default current directory)
+- `-y, --yes` - Skip the confirmation prompt
 
 ### `init`
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -108,7 +108,7 @@ This should start generating traffic that you can see in the Speedscale UI withi
 1. Generate local certs by running the following command (it should say "Certificate was added to keystore"):
 
 ```bash
-proxymock certs --jks
+proxymock admin certs --jks
 ```
 
 2. Start the capture system with this command:


### PR DESCRIPTION
# Problem

The proxymock CLI top-level command tree was decluttered: low-traffic plumbing is now hidden from `proxymock --help` or grouped under a new `admin` noun. The CLI reference and a few tutorial/guide snippets still pointed at the old top-level paths.

# Solution

Update the docs to match the reorganized tree:

- **`proxymock certs` / `proxymock clean` → `proxymock admin certs` / `proxymock admin clean`** in the CLI reference (top-level list + new `admin` section) and in every tutorial/language snippet (`tutorial.md`, `getting-started/tutorial.md`, the sidecar TLS partial, `guides/browser.md`, `reference/languages/java.md`).
- Note that the legacy `proxymock certs` / `proxymock clean` paths still work as hidden aliases for a release or two.

`automation` stays a visible command (unchanged), so the credentials-swap guide is untouched. Matches the CLI change in speedscale/speedscale!6639. No command that carries real traffic was renamed.