### PR TITLE
proxymock: mock match-rate tuning guide + regenerated MCP reference

### DIFF
--- a/docs/proxymock/guides/index.md
+++ b/docs/proxymock/guides/index.md
@@ -4,7 +4,7 @@ description: "Explore practical how-to guides for using proxymock effectively in
 sidebar_position: 3
 ---
 
-import { GrpcCard, OpenApiCard, ModifyRrpairsCard, LlmSimulationCard, DatadogSyntheticsCard, CredentialsSwapCard, RecommendationsCard, ReplayTuningCard } from '@site/src/components/Cards';
+import { GrpcCard, OpenApiCard, ModifyRrpairsCard, LlmSimulationCard, DatadogSyntheticsCard, CredentialsSwapCard, RecommendationsCard, ReplayTuningCard, MockMatchRateCard } from '@site/src/components/Cards';
 
 # Guides
 
@@ -13,6 +13,7 @@ This section contains how-to guides for practical uses of **proxymock**.
 <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1rem', marginTop: '2rem' }}>
   <RecommendationsCard />
   <ReplayTuningCard />
+  <MockMatchRateCard />
   <CredentialsSwapCard />
   <LlmSimulationCard />
   <DatadogSyntheticsCard />

--- a/docs/proxymock/guides/mock-match-rate.md
+++ b/docs/proxymock/guides/mock-match-rate.md
@@ -51,7 +51,7 @@ The recording lands in `proxymock/recorded-<timestamp>/` — real API calls plus
 
 ## 2. Mock and replay: watch the misses happen
 
-Run the app against the mock built from that recording, and replay the recorded tests at it. The beacon generates *new* UUIDs this run, so those requests cannot match:
+Run the app against the mock built from that recording, and replay the recorded tests at it. The beacon generates *new* UUIDs this run, so those requests cannot match. Both terminals run from `mock-lab/go`:
 
 ```shell
 # terminal 1 — app with the downstream mocked (fail closed so misses are visible)

--- a/docs/proxymock/guides/mock-match-rate.md
+++ b/docs/proxymock/guides/mock-match-rate.md
@@ -1,0 +1,134 @@
+---
+title: Improve Mock Match Rate with AI
+description: "Use the improve-mock-match-rate skill and the proxymock MCP tuning tools to find why replayed requests miss their mocks and fix them until the match rate is 100%."
+sidebar_position: 8
+---
+
+# Improve Mock Match Rate with AI
+
+A mock **miss** means your app made an outbound request that no recorded mock could answer. The usual culprits are values that change on every run — a UUID in the URL path, a timestamp or nonce in the body, a trace header — so the replayed request's signature never matches what was recorded.
+
+proxymock ships an AI-agent workflow that fixes this automatically: the **`improve-mock-match-rate` skill** drives four MCP tools in a loop — measure the match rate, group the misses by the fix that would collapse them, accept filter-scoped fixes into the workspace's tuning blueprint, and re-measure — until the projected match rate is as high as it can get. Everything runs offline from RRPair files; no replay is needed between iterations.
+
+This guide walks the loop end to end using [mock-lab](https://github.com/speedscale/mock-lab) as the demo app.
+
+## How it works
+
+The mock server matches each outbound request's **signature** (method, host, URL, query params, body fields) against the recording, after applying the workspace's transform chains (the *tuning blueprint*). A fix is one transform scoped by a filter — e.g. "on `POST /v1/track/{id}`, wildcard the rotating path segment" — written into that blueprint.
+
+Two rates matter, over the same set of outbound requests:
+
+- **Report match rate** — the HIT/MISS verdicts recorded when the traffic actually ran. Ground truth; it never changes offline.
+- **Projected match rate** — what the *next* run would score with the current blueprint applied. It starts at the report rate and climbs as fixes are accepted, using the same matching engine the mock server runs — so the projection is trustworthy.
+
+The agent iterates against the projection and you re-run the replay once at the end to confirm.
+
+## Before you begin
+
+- `proxymock` [installed](../getting-started/quickstart/quickstart-cli.md) and initialized (`proxymock init --api-key <key>`)
+- The proxymock MCP server installed for your AI agent: `proxymock mcp install`. For Claude Code this also installs the `improve-mock-match-rate` skill, so `/improve-mock-match-rate` is available as a slash command; other MCP clients get the same workflow as the `improve_mock_match_rate` prompt.
+- `git` and Go, for the mock-lab example
+
+## 1. Record traffic with a rotating value
+
+Clone mock-lab and record the Go app with its telemetry beacon enabled. The beacon fires `POST /v1/track/{event_id}` downstream on every API request, with a fresh UUID in the path and a timestamp in the body — values that rotate on every run, which is exactly what breaks mock matching in real systems:
+
+```shell
+git clone https://github.com/speedscale/mock-lab.git
+cd mock-lab/go
+EMIT_TELEMETRY=1 proxymock record -- go run .
+```
+
+In a second terminal, drive some traffic through the app, then stop the recording with `Ctrl-C`:
+
+```shell
+for p in / /api/projects /api/categories /api/stats /api/projects/kubernetes; do
+  curl -s -o /dev/null "http://localhost:4143$p"
+done
+```
+
+The recording lands in `proxymock/recorded-<timestamp>/` — real API calls plus one beacon per request, each with a different event id.
+
+## 2. Mock and replay: watch the misses happen
+
+Run the app against the mock built from that recording, and replay the recorded tests at it. The beacon generates *new* UUIDs this run, so those requests cannot match:
+
+```shell
+# terminal 1 — app with the downstream mocked (fail closed so misses are visible)
+EMIT_TELEMETRY=1 proxymock mock --no-passthrough -- go run .
+
+# terminal 2 — replay the recorded inbound tests at the app
+proxymock replay --test-against http://localhost:8080
+```
+
+Stop the mock with `Ctrl-C`. The mock server wrote everything it observed — with a HIT or MISS verdict per request — to `proxymock/results/mocked-<timestamp>/`.
+
+## 3. Let the agent tune it
+
+In your AI agent, from the `mock-lab/go` directory:
+
+```text
+/improve-mock-match-rate
+```
+
+or in any MCP client: *"improve the mock match rate in this workspace"*. The agent runs `analyze_mock_matches`, which finds the two runs on its own (the recording is the mock source, the mock output is the request source) and reports:
+
+```text
+Report match rate:    50% (5/10) — recorded verdicts
+Projected match rate: 50% (5/10) — with 0 active blueprint(s) applied
+
+Recommendation groups (impact-sorted):
+
+1. POST /v1/track/{UUID} — service responder, 5 request(s)
+   - id: responder|url:/v1/track/*
+     fix: URL id segment -> constant
+   - id: responder|body:ts
+     fix: ts -> constant
+```
+
+The analyzer discovered the rotating-UUID family, grouped all five misses under one endpoint-scoped filter, and recommends two fixes: wildcard the rotating path segment, and mask the `ts` timestamp field. The agent accepts them with `accept_mock_recommendation`, and the response reports the movement immediately:
+
+```text
+Accepted all open recommendations: 2 filter-scoped chain(s) written into blueprint(s) responder Mocks.
+
+Projected match rate: 50% (5/10) -> 100% (10/10).
+```
+
+For ambiguous misses the agent digs deeper with `similar_candidates`, which ranks a miss against the nearest recorded signatures and classifies each drifting field's cause (datetime, uuid, jwt, trace-id, pii, opaque). The skill's playbook uses those causes to choose safely — e.g. a PII-classified lookup key gets `smart_replace_recorded` instead of a blind mask, and anything auth-shaped is surfaced to you rather than auto-accepted.
+
+## 4. Confirm with a real run
+
+The accepted fixes live in `proxymock/blueprints/` and the mock server applies them automatically. Re-run step 2 and every request now matches:
+
+```shell
+grep -rho '"match":"[A-Z_]*"' proxymock/results/mocked-<newest>/ | sort | uniq -c
+#   10 "match":"HIT"
+```
+
+## Tuning a cloud replay report
+
+The same loop works on Speedscale Cloud replay reports. Give the agent a report id and the `pull_report` tool materializes both analysis sides — the report's RRPairs (with their recorded verdicts) and the source snapshot — into a local workspace:
+
+```text
+/improve-mock-match-rate report c54ae6fc-947a-4991-a9c1-4d7c32e00b9a
+```
+
+The agent pulls, analyzes, accepts fixes, and iterates exactly as above. When it's done, `push_snapshot` syncs the tuned blueprint back to the cloud so the next in-cluster replay uses it.
+
+## The tools
+
+| Tool | Role |
+| --- | --- |
+| `pull_report` | Pull a cloud replay report and its source snapshot into a local workspace |
+| `analyze_mock_matches` | Report + projected match rates, recommendation groups with accept ids, drift summary |
+| `accept_mock_recommendation` | Accept or undo a fix by id (or `all=true`); reports the rate movement inline |
+| `similar_candidates` | Per-miss deep dive: nearest recorded signatures and per-field drift causes |
+
+See the [MCP Tools & Prompts Reference](../how-it-works/mcp-tools.md) for full parameter documentation, and the [Replay Tuning guide](replay-tuning.md) for the script-based variant of this workflow.
+
+## Good to know
+
+- Fixes are **blueprint-only** — no RRPair files are rewritten, and every accept can be undone.
+- Each fix is **scoped by a filter** (the group's endpoint), so a wildcard on one rotating route can't collapse unrelated endpoints into false matches.
+- Fixes using `smart_replace_recorded` can't be credited by the offline projection (they need recorded data at replay time) — the agent notes them for the confirming run instead of churning.
+- A projected 100% is a projection. The confirming replay in step 4 is the ground truth — in this demo they agree exactly.

--- a/docs/proxymock/how-it-works/mcp-tools.md
+++ b/docs/proxymock/how-it-works/mcp-tools.md
@@ -59,12 +59,33 @@ _No parameters._
 
 Replay recorded RRPairs from test files against an HTTP server URL.
 
+By default each request is replayed once, which acts as a regression test. To run a performance / load test instead, set 'vus' (concurrency) together with 'for' (run for a duration) or 'times' (run a number of iterations), and optionally 'performance' mode for high-throughput runs. Use 'fail-if' to encode a pass/fail condition such as a latency budget.
+
+The replay runs in the background: use the list_running tool to see when it finishes and the read_process_logs tool to inspect results, including whether any 'fail-if' condition triggered. After completion, run the generate_report tool on the output directory for latency percentiles and quality scores.
+
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `in-directory` | array | **yes** | Directories containing the test RRPair files. Directories are read recursively. Usually these directories end with 'proxymock' and are contained in the current repository. |
 | `out-directory` | array | **yes** | Directories to write observed replay request/response files to. Unless otherwise instructed use 'proxymock/replayed-&lt;date&gt;' where &lt;date&gt; is the output from the command 'date +%Y-%m-%d_%H-%M-%S', or something similar. |
+| `fail-if` | string | no | Condition expression that marks the replay as failed (exit code 1) when true, e.g. 'latency.p99 &gt; 100' or 'requests.result-match-pct &lt; 95.5'. Check the process logs to see whether the condition triggered. |
+| `for` | string | no | How long to run the replay, as a Go duration string (e.g. '30s', '5m'). Traffic is replayed continuously, on a loop, until the duration expires. Mutually exclusive with 'times'. Omit both to replay each request exactly once. |
 | `log-to` | string | no | File path to redirect all proxymock output to |
+| `performance` | boolean | no | Performance mode only writes a sample of failed or non-matching requests to disk, trading granular data collection for replay speed. Recommended for high-throughput load tests (many vus or long durations). |
+| `rewrite-host` | boolean | no | Rewrite the HTTP Host header to match the target hostname:port. Set this when the target server routes requests by Host header (e.g. virtual hosts, ingress controllers). |
 | `test-against` | string | no | A partial or full URL which will override some or all of the captured URL during replay. If not provided, the target depends on the traffic. The test-against address may be a full or partial URL which will override the base URL of requests during replay. - If a scheme is provided the scheme of the request will be replaced - If a hostname is provided the hostname of the request will be replaced - If a port is provided the port of the request will be replaced Example test-against addresses: \| Captured URL \| Test Against \| Replay URL \|-----------------------------\|---------------------\|----------- \|https://original.com:443/foo \| http://new.com:8080 \| http://new.com:8080/foo \|https://original.com:443/foo \| http:// \| http://original.com:443/foo \|https://original.com:443/foo \| http://new.com \| http://new.com:443/foo \|https://original.com:443/foo \| new.com \| https://new.com:443/foo \|https://original.com:443/foo \| new.com:8080 \| https://new.com:8080/foo \|https://original.com:443/foo \| :8080 \| https://original.com:8080/foo \|https://original.com:443/foo \| http://:8080 \| http://original.com:8080/foo |
+| `times` | number | no | Number of times to replay the full traffic set (default 1). Mutually exclusive with 'for'. |
+| `vus` | number | no | Number of concurrent virtual users generating load (default 1). Set higher (e.g. 10) together with 'for' or 'times' to run a load test. Each virtual user replays the full traffic set independently. |
+
+#### `send_one`
+
+Send a single RRPair's request to an arbitrary URL and return the live response (status line, headers, and body). The RRPair file is not modified.
+
+Use this to spot-check one endpoint after a code or RRPair change without running a full replay, e.g. after fixing a body with edit_rrpair. The URL overrides the recorded scheme/host/port; the request path comes from the RRPair.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `file` | string | **yes** | Path to the RRPair file (.json or .md) to send, relative to the working directory. Use a test (inbound) RRPair rather than a mock. |
+| `url` | string | **yes** | URL to send the request to, e.g. 'http://localhost:8080'. |
 
 ### Analyze
 
@@ -133,6 +154,248 @@ Statements are fingerprinted: literal values and bind parameters are masked as '
 | `in-directory` | array | **yes** | Directories containing RRPair files to inventory (or the candidate/newer run when comparing). Read recursively. Usually these end with 'proxymock' and are in the current repository. |
 | `baseline-directory` | array | no | Optional baseline (older run) directories. When set, the output is a comparison showing how the input directories' SQL workload changed relative to this baseline — e.g. baseline=recorded traffic, in-directory=replayed traffic, or two recordings of different app versions. |
 
+#### `response_diff`
+
+_Read-only._
+
+Compare the HTTP/gRPC response payloads of two recorded runs and report only the differences that matter. First learns which response fields are volatile (timestamps, ids, counters) from within-run evidence, then diffs the paired responses on the remaining stable fields — so a real regression (a total going to 0, a field disappearing, a type change) surfaces while noise is filtered out.
+
+in-directory is the candidate/newer run; baseline-directory is the baseline/older run — e.g. baseline=recorded traffic, candidate=replayed traffic, or two recordings of different app versions. Twins are paired by refUuid then endpoint+sequence.
+
+Findings are classified (value change, magnitude/sign shift, null flip, type change, field added/removed, endpoint added/removed) and ranked with regressions first. This catches content regressions a status-code or latency monitor cannot: a 200 OK whose body silently changed. Only HTTP/gRPC responses are compared; other protocols are skipped. Companion to generate_report.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `in-directory` | array | **yes** | Directories of RRPair files for the candidate (newer) run. Read recursively. Usually end with 'proxymock' and live in the current repository. |
+| `baseline-directory` | array | **yes** | Directories of RRPair files for the baseline (older/expected) run to compare the candidate against. |
+
+#### `detect_drift`
+
+_Read-only._
+
+Find values that drift (vary) across two or more RRPair directories, e.g. a recording vs. a replay, or several replay runs. Returns a JSON DriftReport listing every field whose value changed between sources, with prefilled transform recommendations for stabilizing mock matching.
+
+Each source is a directory of RRPair files or a single jsonl file (raw.jsonl from a snapshot, raw_rr.jsonl from a report); the formats can be mixed. Sensitivity controls noise filtering:
+- 'permissive': any field that took on more than one value, anywhere
+- 'normal' (default): drift sustained across multiple equivalence classes
+- 'strict': multiple distinct values across multiple classes
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `sources` | array | **yes** | Two or more RRPair directories (or jsonl files) to compare, relative to the working directory. |
+| `sensitivity` | string | no | Drift sensitivity: 'permissive', 'normal' (default), or 'strict'. |
+
+### Tune
+
+#### `list_recommendations`
+
+_Read-only._
+
+Analyze the RRPair (request/response pair) files in a local directory and list tuning recommendations. Two kinds are returned:
+
+- transform: mechanical fixes needed for the traffic to replay or mock cleanly — JWT re-signing, timestamp shifting, message-id rotation, data redaction. Each carries transform chains that apply_recommendation can merge into the workspace's tuning blueprint.
+- traffic: informational findings about the recorded traffic itself.
+
+Recommendation ids are stable content hashes: the same recommendation keeps its id across analysis runs, so an id from this call can be passed to apply_recommendation later. Recommendations the user already rejected are filtered out.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `in-directory` | array | **yes** | Directory containing RRPair files to analyze. Exactly one directory; the tuning blueprint and rejection state are stored under it. Usually ends with 'proxymock' and is contained in the current repository. |
+| `type` | string | no | Optional filter: 'transform' or 'traffic'. Default is both. |
+
+#### `apply_recommendation`
+
+Accept or reject one tuning recommendation by id (from list_recommendations).
+
+Accepting a transform recommendation merges its transform chains into the workspace's per-service tuning blueprint on disk — no RRPair files are rewritten; replay and mock runs in this workspace apply the blueprint automatically. Rejecting records the id in the workspace so the recommendation stops appearing. Both actions are idempotent and match what the proxymock web UI's Accept/Reject buttons do.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `in-directory` | array | **yes** | The same single directory that was analyzed by list_recommendations. The tuning blueprint and rejection state are stored under it. |
+| `id` | string | **yes** | Recommendation id as returned by list_recommendations. |
+| `action` | string | no | 'accept' (default) merges the recommendation into the tuning blueprint; 'reject' hides it from future lists. |
+
+#### `analyze_mock_matches`
+
+_Read-only._
+
+Analyze how well a replay's outbound requests match the recorded mocks, and list tuning recommendations. Works entirely from RRPair files on disk — no replay or cluster needed. Reports two rates over the same outbound denominator:
+
+- Report match rate: the ground-truth verdicts recorded at replay time (what the report showed).
+- Projected match rate: what the rate WOULD be on the next replay with the workspace's active tuning blueprints applied. Always &gt;= the report rate; it climbs as fixes are accepted.
+
+The remaining projected misses are grouped by the fix that would collapse them: each group is a FILTER (the scope — e.g. an endpoint whose URL rotates an id segment) carrying RECOMMENDATIONS (transforms to accept, each with a stable id). Accepting writes one filter-scoped rule into the tuning blueprint via accept_mock_recommendation; re-running this tool then shows the improved projected rate. Iterate until the projected rate stops climbing.
+
+The workspace usually comes from 'proxymock cloud pull report &lt;id&gt;', which materializes both sides (report-* and snapshot-* run directories).
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `in-directory` | array | **yes** | Exactly one workspace directory holding both analysis sides as run directories (usually snapshot-* and report-*). The tuning blueprint is stored under it. |
+| `mock-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the recorded mock signatures. Auto-discovered when omitted: the newest snapshot-*/recorded-*/mocked-* run. |
+| `request-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the outbound requests to check. Auto-discovered when omitted: the newest report-*/replayed-* run. |
+
+#### `accept_mock_recommendation`
+
+Accept or undo one mock-match tuning recommendation by id (from analyze_mock_matches), or accept every open recommendation at once with all=true.
+
+Accepting writes the recommendation's transform as a FILTER-SCOPED rule into the workspace's per-service tuning blueprint — no RRPair files are rewritten; the scope filter (e.g. the endpoint whose URL rotates an id) decides which requests it applies to, and replay/mock runs in this workspace apply the blueprint automatically. Undo removes the rule. Both directions are idempotent, so combinations can be tried and reverted freely; re-accepting with a different transform replaces the prior rule.
+
+The response includes the projected match rate before and after the change, so the improvement (or regression) is visible immediately. This is a different id space from apply_recommendation, which handles the general replay-tuning recommendations; this tool handles the Mocks-view match-rate fixes.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `in-directory` | array | **yes** | The same single workspace directory that was analyzed by analyze_mock_matches. |
+| `action` | string | no | 'accept' (default) writes the fix into the tuning blueprint; 'undo' removes a previously accepted fix. |
+| `all` | boolean | no | Accept every open recommendation with its default transform (the web UI's 'Accept all'). Only valid with action=accept. |
+| `id` | string | no | Recommendation id as returned by analyze_mock_matches (shaped '&lt;service&gt;\|&lt;target&gt;'). Required unless all=true. |
+| `mock-source` | string | no | Optional explicit mock source, as in analyze_mock_matches. |
+| `request-source` | string | no | Optional explicit request source, as in analyze_mock_matches. |
+| `transform` | string | no | Optional transform type overriding the recommendation's default (e.g. 'constant' to mask instead of the recommended transform). Ignored for URL id-segment fixes, which always wildcard. |
+
+#### `similar_candidates`
+
+_Read-only._
+
+Deep-dive on a single projected miss from analyze_mock_matches: rank it against the recorded mock corpus and explain, field by field, why the nearest recorded requests don't match.
+
+Each candidate lists its drifting fields with a classification (drift / volatile / url-param / missing-key), the likely CAUSE of the drift (datetime, uuid, jwt, trace-id, ip, pii, random, opaque), both values, whether an active blueprint already covers the field, and any pending analyzer recommendation for it. 'opaque' causes are flagged low-confidence — the value may be a real discriminator, so review before masking.
+
+Use this to reason about ambiguous misses before accepting fixes with accept_mock_recommendation — e.g. a drifting auth header is a credential to surface to the user, not a field to blindly mask.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `in-directory` | array | **yes** | The same single workspace directory that was analyzed by analyze_mock_matches. |
+| `id` | string | **yes** | A projected miss's id — a group member id or miss id from analyze_mock_matches (the workspace-relative RRPair path). |
+| `max` | number | no | How many nearest candidates to return (default 3). |
+| `mock-source` | string | no | Optional explicit mock source, as in analyze_mock_matches. |
+| `request-source` | string | no | Optional explicit request source, as in analyze_mock_matches. |
+
+### Author configs
+
+#### `config`
+
+Author and validate Speedscale config against local RRPair files, entirely offline (no Speedscale account, API key, or network). Select the operation with 'action':
+
+- 'filter-test' (read-only): report which RRPairs a filter rule keeps versus drops. Matches the engine the forwarder uses: an RRPair that matches the filter is dropped, one that does not is kept.
+- 'transform-test' (read-only): preview what a transform config would change - per-chain match counts, how many RRPairs change, and the before/after of a sampled RRPair. Matches the engine the cloud snapshot Transforms tab and proxymock web use.
+- 'transform-apply' (writes files): write transformed copies of the RRPairs to 'out-directory', mirroring the input layout. Input files are never modified.
+
+The 'config' is the same JSON document 'proxymock cloud pull/push filter|transform' read and write, so a rule authored locally round-trips to and from Speedscale Cloud. To write only the RRPairs a filter keeps, use the 'proxymock filter apply' CLI command.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `action` | string | **yes** | Which config operation to run: 'filter-test' and 'transform-test' are read-only previews; 'transform-apply' writes transformed copies to out-directory. |
+| `config` | string | **yes** | Path to a filter/transform config JSON file, or the id of a config downloaded with 'proxymock cloud pull filter\|transform'. |
+| `in-directory` | array | **yes** | Directories or RRPair files to read, relative to the working directory. Directories are read recursively. |
+| `out-directory` | array | no | Required for 'transform-apply': directory to write transformed copies to (must be outside the input directories). Only the first entry is used. Ignored by the read-only actions. Unless otherwise instructed use 'proxymock/transform-&lt;date&gt;' where &lt;date&gt; is the output from the command 'date +%Y-%m-%d_%H-%M-%S', or something similar. |
+
+#### `dlp`
+
+Author and validate DLP (data loss prevention) redaction rules against local RRPair files, entirely offline (no Speedscale account, API key, or network). The redaction pipeline is identical to what 'proxymock record --dlp-config' applies at capture time, so this reports exactly what a live recording would redact. Select the operation with 'action':
+
+- 'test' (read-only): report what a DLP config would redact without modifying any file - per-location match counts and the file and location of each match. Set 'show-redacted' to a single RRPair file to print its full before/after redaction instead of the summary.
+- 'apply' (writes files): write redacted copies of the RRPairs to 'out-directory', mirroring the input layout. Input files are never modified.
+
+The 'config' is the same JSON document 'proxymock cloud pull/push dlp' read and write, so a rule authored locally round-trips to and from Speedscale Cloud.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `action` | string | **yes** | Which DLP operation to run: 'test' is a read-only report; 'apply' writes redacted copies to out-directory. |
+| `config` | string | **yes** | Path to a DLP config JSON file, or the id of a rule downloaded with 'proxymock cloud pull dlp'. |
+| `in-directory` | array | **yes** | Directories or RRPair files to read, relative to the working directory. Directories are read recursively. |
+| `out-directory` | array | no | Required for 'apply': directory to write redacted copies to (must be outside the input directories). Only the first entry is used. Ignored by 'test'. Unless otherwise instructed use 'proxymock/redacted-&lt;date&gt;' where &lt;date&gt; is the output from the command 'date +%Y-%m-%d_%H-%M-%S', or something similar. |
+| `show-redacted` | string | no | For 'test' only: path to a single RRPair file to print its full before/after redaction instead of the summary. |
+
+### Edit traffic
+
+#### `edit_rrpair`
+
+Replace the request or response body of an RRPair markdown file in the local workspace. Content-Length on the edited side is recomputed automatically and the file is rewritten atomically.
+
+Use this to fix stale recorded data before mocking or replaying, e.g. after search_local_traffic or compare_rrpair_files points you at the file. Only .md RRPair files are editable.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `file` | string | **yes** | Path to the .md RRPair file, relative to the working directory, e.g. 'proxymock/recorded-2026-01-01/my-host/rr.md'. |
+| `side` | string | **yes** | Which body to replace: 'request' or 'response'. |
+| `body` | string | **yes** | The new body content as a UTF-8 string. For binary content prefix with 'base64:' followed by standard base64. An empty string clears the body. |
+
+#### `delete_rrpairs`
+
+Delete RRPair files from the local workspace by explicit path list. There are no wildcard or directory deletes: every file to remove must be named individually, and each file must decode as a valid RRPair before it is deleted.
+
+Paths that fail validation are reported as skipped with a reason and do not abort the rest of the batch. Use search_local_traffic to find the files first.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `files` | array | **yes** | Paths of the .json or .md RRPair files to delete, relative to the working directory. |
+
+### Convert
+
+#### `generate`
+
+Turn an OpenAPI specification into local RRPair files. Parses an OpenAPI 3.0+ spec (JSON or YAML) and writes one or more RRPair files per endpoint with realistic synthesized data. Runs entirely locally with no Speedscale account.
+
+Use 'direction' to pick what to emit:
+- outbound (default): OUTBOUND mock definitions — serve them with 'mock_server_start' (proxymock mock) to stand up a mock of the spec's API, or use them as dependency mocks during 'replay_traffic'.
+- inbound: INBOUND test definitions — drive them at a running implementation of the spec with 'replay_traffic' (proxymock replay).
+- both: an inbound test and an outbound mock per endpoint.
+
+Returns the number of RRPair files generated and the output directory.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spec` | string | **yes** | Path to the OpenAPI 3.0+ specification file (JSON or YAML), relative to the working directory. |
+| `out-directory` | string | **yes** | Directory to write the generated RRPair files to, relative to the working directory. |
+| `direction` | string | no | Which RRPairs to generate: 'outbound' (mocks for the mock server, default), 'inbound' (tests for replay), or 'both'. |
+| `examples-only` | boolean | no | Only generate responses that have an explicit example in the spec, skipping schema-synthesized ones. Defaults to false. |
+| `exclude-paths` | string | no | Comma-separated path patterns to exclude; matching endpoints are skipped. |
+| `host` | string | no | Override the host recorded on generated requests. Defaults to the host from the spec's server URL. |
+| `include-optional` | boolean | no | Include optional schema properties in generated request/response bodies. Defaults to false. |
+| `include-paths` | string | no | Comma-separated path patterns to include; only matching endpoints are generated. |
+| `port` | number | no | Override the port recorded on generated requests. Defaults to the port from the spec, or 80/443. |
+| `tag-filter` | string | no | Only generate endpoints carrying one of these OpenAPI tags (comma-separated). |
+
+#### `import_traffic`
+
+Convert a third-party traffic capture into local RRPair files that proxymock can mock and replay. This is the INBOUND direction: an external artifact becomes RRPairs on disk. Runs entirely locally with no Speedscale account.
+
+Choose the format that matches the source artifact:
+- postman: a Postman collection JSON file (v2.1). Every request becomes an inbound test; requests with a saved example response also become outbound mocks.
+- har: a HAR (HTTP Archive) JSON file. Every entry becomes an inbound test and, because HAR carries the response, an outbound mock.
+- goreplay: a GoReplay capture file (.gor). Every request becomes an inbound test.
+- wiremock: a WireMock project directory or .zip. Every stub mapping becomes an outbound mock.
+- http-wire: a directory or .zip of raw HTTP wire-format files (Req&lt;n&gt;.txt / Res&lt;n&gt;.txt). Every request/response pair becomes an outbound mock.
+
+Returns the number of tests and mocks written and a sample of the RRPair file paths. To go the other way (RRPairs to a third-party format) use export_traffic.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `format` | string | **yes** | Format of the source artifact: 'postman', 'har', 'goreplay' (single file), or 'wiremock', 'http-wire' (directory or .zip). |
+| `source` | string | **yes** | Path to the input artifact, relative to the working directory. A file for postman/har/goreplay; a directory or .zip for wiremock/http-wire. |
+| `out-directory` | string | no | Directory to write RRPair files to. Defaults to ./proxymock/imported-&lt;source-name&gt;. |
+| `service-name` | string | no | Service name recorded on all imported RRPairs. Defaults to 'localhost'. |
+| `target-host` | string | no | wiremock/http-wire only: hostname recorded on each imported mock (for http-wire, a fallback when the request has no Host header). |
+| `target-port` | number | no | wiremock/http-wire only: port recorded on each imported mock. Defaults to 80. |
+
+#### `export_traffic`
+
+Convert local RRPair files into a third-party format. This is the OUTBOUND direction: recorded RRPairs on disk become an artifact another tool can consume. Runs entirely locally (file output only, no publishing to any service).
+
+Choose the target format:
+- postman: a Postman collection JSON file, for driving requests from Postman.
+- k6: a k6 load-test JavaScript file.
+- gatling: a Gatling simulation Java file.
+- datadog-synthetics: a Datadog Synthetics test bundle written to disk (local files only; this tool never publishes to Datadog).
+
+Reads RRPair files from one input directory and writes a single output artifact. To go the other way (a third-party artifact to RRPairs) use import_traffic.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `format` | string | **yes** | Format to export to: 'postman', 'k6', 'gatling', or 'datadog-synthetics'. |
+| `in-directory` | string | **yes** | Directory of recorded RRPair files to export, relative to the working directory (read recursively). |
+| `out` | string | no | Output file (or bundle directory for datadog-synthetics). Defaults per format: collection.json, k6.js, LoadSimulation.java, or a datadog-synthetics-&lt;dir&gt; bundle. |
+
 ### Cloud
 
 #### `pull_remote_recording`
@@ -147,6 +410,19 @@ Pull traffic from a remote service, including backend dependencies. Can accept e
 | `filter-query` | string | no | Optional human-readable filter query string to further filter traffic. Examples: - Filter by method: '(method IS "GET")' - Filter by status: '(status IS "200")' - Filter by URL: '(url CONTAINS "/api/users")' - Filter by cluster: '(cluster IS "production")' - Filter by namespace: '(namespace IS "default")' - Filter by session: '(session IS "session-id-value")' - Text search in request/response bodies: '(text CONTAINS "error message")' - Text search with regex: '(text REGEX "user-[0-9]+")' - Request body JSON match: '(reqbodyjson IS "&#123;\"body\": &#123;\"field\": \"value\"&#125;, \"ignore_keys\": [\"timestamp\"]&#125;")' - Request JSON field: '(req_json[field.path] CONTAINS "value")' - Response JSON field: '(resp_json[field.path] CONTAINS "value")' - Combine filters: '(method IS "GET") AND (status IS "200")' |
 | `snapshot-name` | string | no | Optional custom name for the snapshot. If not provided, defaults to '&#123;service&#125;-&#123;timestamp&#125;'. |
 | `start-time` | string | no | Optional start time for the time range filter in RFC3339 format (e.g., '2024-01-01T00:00:00Z'). If not provided, defaults to 5 minutes ago. |
+
+#### `pull_report`
+
+Pull a Speedscale cloud replay report AND the snapshot it was generated from into a local workspace — the equivalent of 'proxymock cloud pull report &lt;id&gt;'.
+
+The report's RRPairs (carrying the HIT/MISS mock-match verdicts) land in &lt;out-directory&gt;/report-&lt;id&gt;/ and the source snapshot's recorded traffic in a sibling snapshot-&lt;id&gt;/ — exactly the two sides analyze_mock_matches needs, so this tool is step one of the mock match-rate tuning loop: pull_report -&gt; analyze_mock_matches -&gt; accept_mock_recommendation -&gt; repeat.
+
+Report ids come from the Speedscale dashboard's report URL, or from the user. Requires Speedscale cloud credentials (run 'proxymock init' once to register). Distinct from pull_remote_recording, which records fresh traffic by service and time range rather than fetching an existing replay report.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `report-id` | string | **yes** | The report's id, e.g. c54ae6fc-947a-4991-a9c1-4d7c32e00b9a. |
+| `out-directory` | array | **yes** | Workspace directory the report-&lt;id&gt;/ and snapshot-&lt;id&gt;/ trees are created under. Unless otherwise instructed use 'proxymock/pulled-&lt;date&gt;' where &lt;date&gt; is the output from the command 'date +%Y-%m-%d_%H-%M-%S', or something similar. |
 
 #### `search_traffic`
 
@@ -169,6 +445,59 @@ You should:
 | `start-time` | string | **yes** | Start time for the time range filter in RFC3339 format (e.g., '2024-01-01T00:00:00Z') |
 | `end-time` | string | **yes** | End time for the time range filter in RFC3339 format (e.g., '2024-01-01T23:59:59Z') |
 | `filter-query` | string | no | Optional human-readable filter query string to further filter traffic. Examples: - Filter by method: '(method IS "GET")' - Filter by status: '(status IS "200")' - Filter by URL: '(url CONTAINS "/api/users")' - Filter by cluster: '(cluster IS "production")' - Filter by namespace: '(namespace IS "default")' - Filter by session: '(session IS "session-id-value")' - Text search in request/response bodies: '(text CONTAINS "error message")' - Text search with regex: '(text REGEX "user-[0-9]+")' - Request body JSON match: '(reqbodyjson IS "&#123;\"body\": &#123;\"field\": \"value\"&#125;, \"ignore_keys\": [\"timestamp\"]&#125;")' - Request JSON field: '(req_json[field.path] CONTAINS "value")' - Response JSON field: '(resp_json[field.path] CONTAINS "value")' - Combine filters: '(method IS "GET") AND (status IS "200")' |
+
+#### `push_snapshot`
+
+Publish local RRPair (request/response pair) directories to Speedscale cloud as a named snapshot. Every RRPair under the given directories is consolidated into one snapshot, uploaded, and analyzed by the cloud, making the traffic available to teammates, CI replays, and the dashboard.
+
+Curate the directories first — no filtering is applied. Active tuning blueprints in the workspace are uploaded with the snapshot, so recommendations accepted via apply_recommendation travel with the traffic. Requires Speedscale cloud credentials (run 'proxymock init' once to register).
+
+Returns the new snapshot id and dashboard URL. Use list_cloud_snapshots to confirm the upload or pull_remote_recording to bring a snapshot back down.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `in-directory` | array | **yes** | Directories containing the RRPair files to publish. Read recursively; all RRPairs are consolidated into a single snapshot. |
+| `name` | string | no | Optional display name for the snapshot in the dashboard. |
+
+#### `list_cloud_snapshots`
+
+_Read-only._
+
+List traffic snapshots stored in Speedscale cloud, newest first. Use this to find a snapshot id for pull_remote_recording, or to confirm a push_snapshot upload landed. Requires Speedscale cloud credentials (run 'proxymock init' once to register).
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `limit` | number | no | Maximum snapshots to return (default 20, max 100). |
+| `search` | string | no | Optional search term matched against snapshot names. |
+| `service` | string | no | Optional filter: only snapshots containing traffic for this service. |
+| `tag` | string | no | Optional filter: only snapshots with this build tag. |
+
+### BYOC bucket
+
+#### `pull_byoc_bucket`
+
+Pull historical traffic from the customer's OWN BYOC object-store bucket (S3 or S3-compatible) into local RRPair files that proxymock can search, mock, and replay. Runs entirely locally with no Speedscale account: credentials come from the standard AWS environment credential chain (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_PROFILE, etc.).
+
+This is distinct from pull_remote_recording, which pulls from Speedscale-managed cloud. Use this tool when the traffic lives in the customer's own bucket — for example a BYOC deployment where the in-cluster OTel collector's awss3 exporter writes OTLP-JSON objects under the "byoc/" prefix.
+
+Narrow the pull with a time window (from/to) and filters (service, namespace, status, trace-id, or a full filter expression) so you download only what you need. Returns the import summary: RRPair files written, keys scanned, objects downloaded, and malformed records skipped.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `bucket` | string | **yes** | Name of the S3 (or S3-compatible) bucket that holds the BYOC traffic. |
+| `filter` | string | no | Speedscale traffic filter string, for example '(service IS "checkout") AND (status IS "500")'. Overlapping criteria override the convenience filters below. |
+| `from` | string | no | Start of the time window when the filter has no timerange, for example now-15m or 2026-06-12T18:00:00Z. Defaults to now-1h. |
+| `limit` | number | no | Maximum number of matched RRPairs to write. 0 (default) means unlimited. |
+| `namespace` | string | no | Kubernetes namespace to match when the filter has no namespace predicate. |
+| `out-directory` | string | no | Directory to write RRPair files to. Defaults to ./proxymock/imported-s3-&lt;timestamp&gt;. |
+| `prefix` | string | no | Object key prefix to search. Use 'byoc/' for the current OTel awss3 layout. Defaults to the whole bucket. |
+| `region` | string | no | AWS region of the bucket. Defaults to the AWS SDK configuration (AWS_REGION). |
+| `s3-endpoint-url` | string | no | Custom endpoint URL for an S3-compatible store (MinIO, DigitalOcean Spaces, GCS S3-interop). Leave empty for AWS S3. |
+| `s3-force-path-style` | boolean | no | Use path-style S3 addressing (bucket in the path, not the host). Often required for MinIO and other S3-compatible stores. |
+| `service` | string | no | Service name to match when the filter has no service predicate. |
+| `status` | string | no | Exact response status to match when the filter has no status predicate, for example 500. |
+| `to` | string | no | End of the time window when the filter has no timerange, for example now or 2026-06-12T19:00:00Z. Defaults to now. |
+| `trace-id` | string | no | Trace ID to match when the filter has no trace predicate. |
 
 ### Process control
 
@@ -230,6 +559,12 @@ Try saying: "investigate report", "debug report", "analyze report", "report fail
 Investigate a Speedscale snapshot - debug missing traffic, analyze captured services, diagnose quality issues, and understand snapshot processing.
 
 Try saying: "investigate snapshot", "debug snapshot", "analyze snapshot", "what's in this snapshot", "why is my snapshot", "snapshot traffic", "debug recording", "check my capture", "snapshot quality"
+
+#### `improve_mock_match_rate`
+
+Pull a replay report and iteratively tune the workspace's mock blueprints — analyze, accept filter-scoped fixes, re-analyze — until the projected mock match rate is as high as it can get.
+
+Try saying: "improve match rate", "mock match rate", "tune mocks", "fix mock matching", "increase match rate", "improve mocks", "tune blueprints"
 
 ## Resources
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,19 +54,11 @@ const config = {
           },
           {
             from: "/proxymock/getting-started/quickstart-cli/",
-            to: "/proxymock/getting-started/quickstart/local/",
-          },
-          {
-            from: "/proxymock/getting-started/quickstart/quickstart-cli/",
-            to: "/proxymock/getting-started/quickstart/local/",
-          },
-          {
-            from: "/proxymock/getting-started/quickstart/quickstart-mcp/",
-            to: "/proxymock/getting-started/quickstart/local/",
+            to: "/proxymock/getting-started/quickstart/quickstart-cli/",
           },
           {
             from: "/proxymock/getting-started/quickstart-mcp/",
-            to: "/proxymock/getting-started/quickstart/local/",
+            to: "/proxymock/getting-started/quickstart/quickstart-mcp/",
           },
           {
             from: "/proxymock/getting-started/api-key/",

--- a/src/components/Cards/MockMatchRateCard.js
+++ b/src/components/Cards/MockMatchRateCard.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import Card from '@site/src/components/Card';
+import CardHeader from '@site/src/components/Card/CardHeader';
+import CardBody from '@site/src/components/Card/CardBody';
+import CardFooter from '@site/src/components/Card/CardFooter';
+
+const MockMatchRateCard = () => {
+  return (
+    <Card shadow="md">
+      <CardHeader
+        style={{ backgroundColor: '#f8f9fa', borderBottom: '1px solid #e0e0e0' }}
+        textAlign="center"
+        weight="Bold"
+      >
+        <h3 style={{ margin: 0, marginBottom: '1rem' }}>Mock Match Rate</h3>
+      </CardHeader>
+      <CardBody className="padding-vert--md">
+        Let an AI agent find why replayed requests miss their mocks and accept
+        filter-scoped fixes until the match rate is 100%.
+      </CardBody>
+      <CardFooter style={{ backgroundColor: '#f8f9fa', textAlign: 'center' }}>
+        <a href="/proxymock/guides/mock-match-rate" className="button button--primary">Improve Match Rate</a>
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default MockMatchRateCard;

--- a/src/components/Cards/index.js
+++ b/src/components/Cards/index.js
@@ -26,3 +26,4 @@ export { default as DatadogSyntheticsCard } from './DatadogSyntheticsCard';
 export { default as CredentialsSwapCard } from './CredentialsSwapCard';
 export { default as RecommendationsCard } from './RecommendationsCard';
 export { default as ReplayTuningCard } from './ReplayTuningCard';
+export { default as MockMatchRateCard } from './MockMatchRateCard';


### PR DESCRIPTION
## New guide: Improve Mock Match Rate with AI

[`docs/proxymock/guides/mock-match-rate.md`](https://github.com/speedscale/docs/blob/mock-match-rate-guide/docs/proxymock/guides/mock-match-rate.md) — how to use the **`improve-mock-match-rate` skill** (installed by `proxymock mcp install`) and the proxymock MCP tuning tools in a measure → accept → re-measure loop:

| Tool | Role |
| --- | --- |
| `pull_report` | Pull a cloud replay report + source snapshot into a local workspace |
| `analyze_mock_matches` | Report + projected match rates, recommendation groups, drift summary |
| `accept_mock_recommendation` | Accept/undo a fix by id; reports the rate movement inline |
| `similar_candidates` | Per-miss deep dive with per-field drift causes |

The walkthrough uses [mock-lab](https://github.com/speedscale/mock-lab)'s new opt-in telemetry beacon (`EMIT_TELEMETRY=1`, speedscale/mock-lab#19) to produce misses **by construction**: record 5 rotating-UUID beacons → mock + replay (5 HIT / 5 MISS) → the agent groups the misses as `POST /v1/track/{UUID}`, accepts the two recommended fixes (URL wildcard + `ts` mask), **projected 50% → 100%** → a real re-run confirms **10/10 HIT**. Every command and output shown in the guide is from a live run.

Covers both the fully-local loop and the cloud-report variant (`pull_report` → tune → `push_snapshot`), plus the guardrails (blueprint-only, filter-scoped fixes, `smart_replace_recorded` projection caveat).

## Also

- Regenerated `how-it-works/mcp-tools.md` from `proxymock mcp docs` — picks up the four new tuning tools and the `improve_mock_match_rate` prompt (+335 lines).
- New `MockMatchRateCard` on the guides index.

`yarn build` passes (only pre-existing redirect warnings).

⚠️ Merge after: speedscale/mock-lab#19 (the beacon the guide records) and the speedscale MR stack ending at !6647 (the tools/skill the guide documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)