### PR TITLE
Update proxymock mock-tuning guides and MCP reference

### DIFF
--- a/docs/proxymock/guides/mock-match-rate.md
+++ b/docs/proxymock/guides/mock-match-rate.md
@@ -77,7 +77,7 @@ In your AI agent, from the `mock-lab/go` directory:
 /improve-mock-match-rate
 ```
 
-or in any MCP client: *"improve the mock match rate in this workspace"*. The agent runs `analyze_mock_matches`, which finds the two runs on its own (the recording is the mock source, the mock output is the request source) and reports:
+or in any MCP client: *"improve the mock match rate in this workspace"*. The agent runs the `mocks` tool with `action=analyze`, which finds the two runs on its own (the recording is the mock source, the mock output is the request source) and reports:
 
 ```text
 Report match rate:    ~40% — recorded verdicts
@@ -98,7 +98,7 @@ Recommendation groups (impact-sorted):
    - responder|body:variables.id  fix: variables.id -> constant
 ```
 
-The analyzer groups the misses by endpoint and recommends one fix per rotating value. On `/v1/track` it wildcards the rotating path segment and masks the body timestamp plus each time-anchored query id — the epoch, Snowflake, ObjectId, UUIDv7, xid, and KSUID are recognized because each embeds a timestamp that lands inside the recording's own capture window. On `/graphql` it masks only the rotating `variables.id` and leaves the `query`/`operationName` that identify the operation untouched. The agent accepts them with `accept_mock_recommendation`:
+The analyzer groups the misses by endpoint and recommends one fix per rotating value. On `/v1/track` it wildcards the rotating path segment and masks the body timestamp plus each time-anchored query id — the epoch, Snowflake, ObjectId, UUIDv7, xid, and KSUID are recognized because each embeds a timestamp that lands inside the recording's own capture window. On `/graphql` it masks only the rotating `variables.id` and leaves the `query`/`operationName` that identify the operation untouched. The agent accepts them with `mocks` `action=accept`:
 
 ```text
 Accepted all open recommendations: N filter-scoped chain(s) written into blueprint(s) responder Mocks.
@@ -108,7 +108,7 @@ Projected match rate: ~40% -> 100%.
 
 Exact totals scale with how much traffic you drive; the shape — one group per endpoint, one fix per rotating value — is what matters.
 
-For ambiguous misses the agent digs deeper with `similar_candidates`, which ranks a miss against the nearest recorded signatures and classifies each drifting field's cause (datetime, epoch, uuid, uuidv7, ulid, ksuid, xid, snowflake, objectid, jwt, trace-id, pii, opaque). The skill's playbook uses those causes to choose safely — e.g. a PII-classified lookup key gets `smart_replace_recorded` instead of a blind mask, and anything auth-shaped is surfaced to you rather than auto-accepted.
+For ambiguous misses the agent digs deeper with `mocks` `action=similar`, which ranks a miss against the nearest recorded signatures and classifies each drifting field's cause (datetime, epoch, uuid, uuidv7, ulid, ksuid, xid, snowflake, objectid, jwt, trace-id, pii, opaque). The skill's playbook uses those causes to choose safely — e.g. a PII-classified lookup key gets `smart_replace_recorded` instead of a blind mask, and anything auth-shaped is surfaced to you rather than auto-accepted.
 
 ## 4. Confirm with a real run
 
@@ -134,9 +134,11 @@ The agent pulls, analyzes, accepts fixes, and iterates exactly as above. When it
 | Tool | Role |
 | --- | --- |
 | `pull_report` | Pull a cloud replay report and its source snapshot into a local workspace |
-| `analyze_mock_matches` | Report + projected match rates, recommendation groups with accept ids, drift summary |
-| `accept_mock_recommendation` | Accept or undo a fix by id (or `all=true`); reports the rate movement inline |
-| `similar_candidates` | Per-miss deep dive: nearest recorded signatures and per-field drift causes |
+| `mocks` (`action=analyze`) | Report + projected match rates, recommendation groups with accept ids, drift summary |
+| `mocks` (`action=accept` / `action=undo`) | Accept or undo a fix by id (or `all=true`); reports the rate movement inline |
+| `mocks` (`action=similar`) | Per-miss deep dive: nearest recorded signatures and per-field drift causes |
+
+The prior standalone `analyze_mock_matches`, `accept_mock_recommendation`, and `similar_candidates` tools still work as deprecated aliases of `mocks` for one release.
 
 See the [MCP Tools & Prompts Reference](../how-it-works/mcp-tools.md) for full parameter documentation, and the [Replay Tuning guide](replay-tuning.md) for the script-based variant of this workflow.
 

--- a/docs/proxymock/guides/mock-match-rate.md
+++ b/docs/proxymock/guides/mock-match-rate.md
@@ -20,7 +20,7 @@ The mock server matches each outbound request's **signature** (method, host, URL
 
 Two rates matter, over the same set of outbound requests:
 
-- **Report match rate** — the HIT/MISS verdicts recorded when the traffic actually ran. Ground truth; it never changes offline.
+- **Report match rate** — the HIT/MISS verdicts recorded when the traffic actually ran. It never changes offline.
 - **Projected match rate** — what the *next* run would score with the current blueprint applied. It starts at the report rate and climbs as fixes are accepted, using the same matching engine the mock server runs — so the projection is trustworthy.
 
 The agent iterates against the projection and you re-run the replay once at the end to confirm.
@@ -152,4 +152,4 @@ See the [MCP Tools & Prompts Reference](../how-it-works/mcp-tools.md) for full p
 - A rotating id in a URL path that was **created earlier in the session** — issued by a `POST`/`PUT`/`PATCH` response (a `Location` header or a body id) and then used in a later request's path — is called out under **Created ids** (a CREATE→USE list) and is *not* offered a wildcard. Wildcarding `/orders/*` would match ids the mock never issued; at mock time the client reuses the id the mock returned, so the request matches on its own. mock-lab's `POST /v1/orders` → `GET /v1/orders/{id}` flow shows this against the lab reference server.
 - Auth and session correlations — an OAuth token, a rotated session cookie, a CSRF double-submit, an `ETag`→`If-None-Match` — are collected under **Credentials & session**. These ride in headers, which are *outside* the mock signature, so they never cause a mock miss and get no fix here; but the credential-carrying ones authenticate the caller, so a *validating* replay must correlate them — the advisory flags those for review and points at credential setup. mock-lab's `POST /v1/auth/token` → `GET /v1/me` (bearer + session cookie) flow shows this against the lab reference server.
 - Response fields that vary across *identical* requests but are just noise — a timestamp, a server-issued id, a rate-limit counter — are separated out as **volatile response fields** (a NOISE list) rather than making the endpoint look stateful. They're found by observation, not a format rule, so app-specific noise is caught too; a mock ignores them, but they're worth knowing for response-diff / assertion tuning. mock-lab's `GET /v1/job/status` carries a rotating `checkedAt` alongside its real `status`, and `GET /v1/time` returns only a rotating `now` — the first stays stateful with `checkedAt` flagged noise, the second isn't flagged at all.
-- A projected 100% is a projection. The confirming replay in step 4 is the ground truth — in this demo they agree exactly.
+- A projected 100% is a projection. The confirming replay in step 4 is the real result; in this demo they agree exactly.

--- a/docs/proxymock/guides/mock-match-rate.md
+++ b/docs/proxymock/guides/mock-match-rate.md
@@ -12,6 +12,8 @@ proxymock ships an AI-agent workflow that fixes this automatically: the **`impro
 
 This guide walks the loop end to end using [mock-lab](https://github.com/speedscale/mock-lab) as the demo app.
 
+Prefer a script, or gating the match rate in CI? [Tune a Replay Locally](./replay-tuning.md) covers the `proxymock-replay-tuning` CLI: it measures HIT/MISS/PASSTHROUGH and fails a build below a threshold, no AI agent required.
+
 ## How it works
 
 The mock server matches each outbound request's **signature** (method, host, URL, query params, body fields) against the recording, after applying the workspace's transform chains (the *tuning blueprint*). A fix is one transform scoped by a filter — e.g. "on `POST /v1/track/{id}`, wildcard the rotating path segment" — written into that blueprint.

--- a/docs/proxymock/guides/replay-tuning.md
+++ b/docs/proxymock/guides/replay-tuning.md
@@ -10,7 +10,7 @@ A replay miss usually means the app made an outbound request that the mock set c
 
 This guide shows a scripted local loop for finding those misses and deciding what to change. You record traffic from [mock-lab](https://github.com/speedscale/mock-lab), run the tuning script, then inspect the `summary.json` and `mock-output/` artifacts it produces. Because it is a single command with a `--fail-under` threshold, it also drops straight into CI.
 
-Looking to have an AI agent find and fix the misses for you — analyze each miss and accept mock recommendations until the match rate reaches 100%? See [Improve Mock Match Rate with AI](./mock-match-rate.md). This guide is the scripted counterpart.
+Looking to have an AI agent analyze each miss and accept mock recommendations until the match rate reaches 100%? See [Improve Mock Match Rate with AI](./mock-match-rate.md). This guide is the scripted counterpart.
 
 The workflow is file-based. It does not require Kubernetes or Speedscale Cloud access.
 
@@ -21,7 +21,6 @@ Make sure you have:
 - `proxymock` [installed](../getting-started/quickstart/quickstart-cli.md)
 - `git`
 - Go installed, for the mock-lab example
-- An AI coding agent that can read local files and run shell commands
 
 The example uses the Go app in `mock-lab`, but the same pattern works with any app that proxymock can record.
 
@@ -61,20 +60,23 @@ The script takes one input:
 | Input | Meaning |
 |---|---|
 | `--in` | A recording to tune. Its outbound pairs are replayed against the mock; its inbound pairs are skipped automatically. |
+| `--fail-under` | Optional minimum hit-rate percentage. The command exits nonzero when the result falls below it, making the check suitable for CI. |
 
 Point it at the recording you just made:
 
 ```shell
-./skills/proxymock-replay-tuning/scripts/tune-proxymock-replay.sh --in replay-work/recording
+./skills/proxymock-replay-tuning/scripts/tune-proxymock-replay.sh \
+  --in replay-work/recording \
+  --fail-under 95
 ```
 
 The skill that wraps this lives in the repo at `skills/proxymock-replay-tuning/SKILL.md`.
 
 Because the mock set and the replay set come from the same recording here, a clean recording matches itself and reports a high hit rate. Misses show up once the mock set falls behind the traffic: a new endpoint, a stale recording, or a signature that pins a value which changes every run. To watch the tuner surface those on purpose, run the [proof script](#prove-the-workflow), which breaks a mock set and measures the misses.
 
-## 4. Start your AI agent
+## 4. Optional: ask an AI agent to interpret the run
 
-Start your AI coding agent from the `mock-lab` repo root. Ask it to use the replay tuning skill and give it the recording:
+If you want help interpreting the artifacts, start your AI coding agent from the `mock-lab` repo root. Ask it to use the replay tuning skill and give it the recording:
 
 ```text
 Use the proxymock-replay-tuning skill to tune this replay.
@@ -82,7 +84,7 @@ Recording: replay-work/recording
 Run the tuning script, summarize HIT/MISS/PASSTHROUGH, and recommend what transforms or recordings need to change.
 ```
 
-You can run the script yourself if you do not want to use an agent.
+Skip this step when running the script directly or in CI.
 
 ## 5. Read the results
 
@@ -126,7 +128,9 @@ For dynamic IDs and bearer tokens, start with [Fix Replay Failures with Recommen
 After each change, rerun the same tuning command:
 
 ```shell
-./skills/proxymock-replay-tuning/scripts/tune-proxymock-replay.sh --in replay-work/recording
+./skills/proxymock-replay-tuning/scripts/tune-proxymock-replay.sh \
+  --in replay-work/recording \
+  --fail-under 95
 ```
 
 Compare the new `summary.json` to the previous run. The loop is:

--- a/docs/proxymock/guides/replay-tuning.md
+++ b/docs/proxymock/guides/replay-tuning.md
@@ -1,14 +1,16 @@
 ---
 title: Tune a Replay Locally
-description: "Use mock-lab, an AI coding agent, and the proxymock replay tuning script to measure replay misses and improve local mock coverage."
-sidebar_position: 8
+description: "Use mock-lab and the proxymock replay tuning script to measure replay misses and gate a match-rate threshold, offline and in CI."
+sidebar_position: 9
 ---
 
 # Tune a Replay Locally
 
 A replay miss usually means the app made an outbound request that the mock set cannot explain. The request may be new, the signature may include a value that changes on every run, or the mock recording may be missing traffic.
 
-This guide shows a local loop for finding those misses and deciding what to change. You will record traffic from [mock-lab](https://github.com/speedscale/mock-lab), ask an AI coding agent to run the replay tuning skill, then inspect the `summary.json` and `mock-output/` artifacts it produces.
+This guide shows a scripted local loop for finding those misses and deciding what to change. You record traffic from [mock-lab](https://github.com/speedscale/mock-lab), run the tuning script, then inspect the `summary.json` and `mock-output/` artifacts it produces. Because it is a single command with a `--fail-under` threshold, it also drops straight into CI.
+
+Looking to have an AI agent find and fix the misses for you — analyze each miss and accept mock recommendations until the match rate reaches 100%? See [Improve Mock Match Rate with AI](./mock-match-rate.md). This guide is the scripted counterpart.
 
 The workflow is file-based. It does not require Kubernetes or Speedscale Cloud access.
 

--- a/docs/proxymock/how-it-works/mcp-tools.md
+++ b/docs/proxymock/how-it-works/mcp-tools.md
@@ -217,12 +217,12 @@ Accepting a transform recommendation merges its transform chains into the worksp
 
 #### `mocks`
 
-Tune a replay's OUTBOUND mock match rate offline, from RRPair files in one workspace — no replay or cluster needed. Select the operation with 'action':
+Tune a replay's OUTBOUND mock match rate offline from RRPair files in one workspace. No replay or cluster is needed. Select the operation with 'action':
 
-- 'analyze' (read-only): report how well the replay's outbound requests match the recorded mocks, and list impact-sorted fix recommendations grouped by the filter that would collapse them. Reports two rates over the same denominator — the report (ground-truth) rate recorded at replay time, and the projected rate with the workspace's active tuning blueprints applied.
+- 'analyze' (read-only): report how well the replay's outbound requests match the recorded mocks, and list impact-sorted fix recommendations grouped by the filter that would collapse them. Reports two rates over the same denominator: the report rate recorded at replay time and the projected rate with the workspace's active tuning blueprints applied.
 - 'accept' (writes blueprint): accept one recommendation by 'id' (from analyze), or every open one with 'all'=true. Writes a filter-scoped transform into the workspace's per-service tuning blueprint; no RRPair files are rewritten. The response reports the projected-rate movement immediately.
 - 'undo' (writes blueprint): remove a previously accepted recommendation by 'id'. Idempotent, so accepts and undos can be tried and reverted freely.
-- 'similar' (read-only): deep-dive one projected miss ('id'), ranking it against the recorded mock corpus with per-field drift, likely cause, and any pending recommendation — to reason about ambiguous misses before accepting fixes.
+- 'similar' (read-only): deep-dive one projected miss ('id'), ranking it against the recorded mock corpus with per-field drift, likely cause, and any pending recommendation. Use it to reason about ambiguous misses before accepting fixes.
 
 The workspace usually comes from 'proxymock cloud pull report &lt;id&gt;', which materializes both analysis sides (snapshot-* and report-* run directories). This is the Mocks-view match-rate loop; it is a different id space from apply_recommendation, which handles general replay-tuning recommendations.
 
@@ -231,7 +231,7 @@ The workspace usually comes from 'proxymock cloud pull report &lt;id&gt;', which
 | `action` | string | **yes** | Which mocks operation to run: 'analyze' and 'similar' are read-only; 'accept' and 'undo' write the tuning blueprint. |
 | `in-directory` | array | **yes** | Exactly one workspace directory holding both analysis sides as run directories (usually snapshot-* and report-*). The tuning blueprint is stored under it. |
 | `all` | boolean | no | action=accept only: accept every open recommendation with its default transform (the web UI's 'Accept all'). |
-| `id` | string | no | A recommendation id (shaped '&lt;service&gt;\|&lt;target&gt;') for action=accept/undo, or a projected-miss id for action=similar — both as returned by action=analyze. Required for accept (unless all=true), undo, and similar. |
+| `id` | string | no | A recommendation id (shaped '&lt;service&gt;\|&lt;target&gt;') for action=accept/undo, or a projected-miss id for action=similar. Both are returned by action=analyze. Required for accept (unless all=true), undo, and similar. |
 | `max` | number | no | action=similar only: how many nearest candidates to return (default 3). |
 | `mock-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the recorded mock signatures. Auto-discovered when omitted: the newest snapshot-*/recorded-*/mocked-* run. |
 | `request-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the outbound requests to check. Auto-discovered when omitted: the newest report-*/replayed-* run. |
@@ -241,11 +241,11 @@ The workspace usually comes from 'proxymock cloud pull report &lt;id&gt;', which
 
 _Read-only._
 
-DEPRECATED — use the `mocks` tool with action=analyze instead. This alias forwards to the same implementation and will be removed in a future release.
+DEPRECATED: use the `mocks` tool with action=analyze instead. This alias forwards to the same implementation and will be removed in a future release.
 
 Analyze how well a replay's outbound requests match the recorded mocks, and list tuning recommendations. Works entirely from RRPair files on disk — no replay or cluster needed. Reports two rates over the same outbound denominator:
 
-- Report match rate: the ground-truth verdicts recorded at replay time (what the report showed).
+- Report match rate: the verdicts recorded at replay time (what the report showed).
 - Projected match rate: what the rate WOULD be on the next replay with the workspace's active tuning blueprints applied. Always &gt;= the report rate; it climbs as fixes are accepted.
 
 The remaining projected misses are grouped by the fix that would collapse them: each group is a FILTER (the scope — e.g. an endpoint whose URL rotates an id segment) carrying RECOMMENDATIONS (transforms to accept, each with a stable id). Accepting writes one filter-scoped rule into the tuning blueprint via accept_mock_recommendation; re-running this tool then shows the improved projected rate. Iterate until the projected rate stops climbing.
@@ -260,7 +260,7 @@ The workspace usually comes from 'proxymock cloud pull report &lt;id&gt;', which
 
 #### `accept_mock_recommendation`
 
-DEPRECATED — use the `mocks` tool with action=accept|undo instead. This alias forwards to the same implementation and will be removed in a future release.
+DEPRECATED: use the `mocks` tool with action=accept|undo instead. This alias forwards to the same implementation and will be removed in a future release.
 
 Accept or undo one mock-match tuning recommendation by id (from analyze_mock_matches), or accept every open recommendation at once with all=true.
 
@@ -282,7 +282,7 @@ The response includes the projected match rate before and after the change, so t
 
 _Read-only._
 
-DEPRECATED — use the `mocks` tool with action=similar instead. This alias forwards to the same implementation and will be removed in a future release.
+DEPRECATED: use the `mocks` tool with action=similar instead. This alias forwards to the same implementation and will be removed in a future release.
 
 Deep-dive on a single projected miss from analyze_mock_matches: rank it against the recorded mock corpus and explain, field by field, why the nearest recorded requests don't match.
 

--- a/docs/proxymock/how-it-works/mcp-tools.md
+++ b/docs/proxymock/how-it-works/mcp-tools.md
@@ -215,9 +215,33 @@ Accepting a transform recommendation merges its transform chains into the worksp
 | `id` | string | **yes** | Recommendation id as returned by list_recommendations. |
 | `action` | string | no | 'accept' (default) merges the recommendation into the tuning blueprint; 'reject' hides it from future lists. |
 
+#### `mocks`
+
+Tune a replay's OUTBOUND mock match rate offline, from RRPair files in one workspace — no replay or cluster needed. Select the operation with 'action':
+
+- 'analyze' (read-only): report how well the replay's outbound requests match the recorded mocks, and list impact-sorted fix recommendations grouped by the filter that would collapse them. Reports two rates over the same denominator — the report (ground-truth) rate recorded at replay time, and the projected rate with the workspace's active tuning blueprints applied.
+- 'accept' (writes blueprint): accept one recommendation by 'id' (from analyze), or every open one with 'all'=true. Writes a filter-scoped transform into the workspace's per-service tuning blueprint; no RRPair files are rewritten. The response reports the projected-rate movement immediately.
+- 'undo' (writes blueprint): remove a previously accepted recommendation by 'id'. Idempotent, so accepts and undos can be tried and reverted freely.
+- 'similar' (read-only): deep-dive one projected miss ('id'), ranking it against the recorded mock corpus with per-field drift, likely cause, and any pending recommendation — to reason about ambiguous misses before accepting fixes.
+
+The workspace usually comes from 'proxymock cloud pull report &lt;id&gt;', which materializes both analysis sides (snapshot-* and report-* run directories). This is the Mocks-view match-rate loop; it is a different id space from apply_recommendation, which handles general replay-tuning recommendations.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `action` | string | **yes** | Which mocks operation to run: 'analyze' and 'similar' are read-only; 'accept' and 'undo' write the tuning blueprint. |
+| `in-directory` | array | **yes** | Exactly one workspace directory holding both analysis sides as run directories (usually snapshot-* and report-*). The tuning blueprint is stored under it. |
+| `all` | boolean | no | action=accept only: accept every open recommendation with its default transform (the web UI's 'Accept all'). |
+| `id` | string | no | A recommendation id (shaped '&lt;service&gt;\|&lt;target&gt;') for action=accept/undo, or a projected-miss id for action=similar — both as returned by action=analyze. Required for accept (unless all=true), undo, and similar. |
+| `max` | number | no | action=similar only: how many nearest candidates to return (default 3). |
+| `mock-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the recorded mock signatures. Auto-discovered when omitted: the newest snapshot-*/recorded-*/mocked-* run. |
+| `request-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the outbound requests to check. Auto-discovered when omitted: the newest report-*/replayed-* run. |
+| `transform` | string | no | action=accept only: transform type overriding the recommendation's default (e.g. 'constant' to mask). Ignored for URL id-segment fixes, which always wildcard. |
+
 #### `analyze_mock_matches`
 
 _Read-only._
+
+DEPRECATED — use the `mocks` tool with action=analyze instead. This alias forwards to the same implementation and will be removed in a future release.
 
 Analyze how well a replay's outbound requests match the recorded mocks, and list tuning recommendations. Works entirely from RRPair files on disk — no replay or cluster needed. Reports two rates over the same outbound denominator:
 
@@ -235,6 +259,8 @@ The workspace usually comes from 'proxymock cloud pull report &lt;id&gt;', which
 | `request-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the outbound requests to check. Auto-discovered when omitted: the newest report-*/replayed-* run. |
 
 #### `accept_mock_recommendation`
+
+DEPRECATED — use the `mocks` tool with action=accept|undo instead. This alias forwards to the same implementation and will be removed in a future release.
 
 Accept or undo one mock-match tuning recommendation by id (from analyze_mock_matches), or accept every open recommendation at once with all=true.
 
@@ -255,6 +281,8 @@ The response includes the projected match rate before and after the change, so t
 #### `similar_candidates`
 
 _Read-only._
+
+DEPRECATED — use the `mocks` tool with action=similar instead. This alias forwards to the same implementation and will be removed in a future release.
 
 Deep-dive on a single projected miss from analyze_mock_matches: rank it against the recorded mock corpus and explain, field by field, why the nearest recorded requests don't match.
 
@@ -415,7 +443,7 @@ Pull traffic from a remote service, including backend dependencies. Can accept e
 
 Pull a Speedscale cloud replay report AND the snapshot it was generated from into a local workspace — the equivalent of 'proxymock cloud pull report &lt;id&gt;'.
 
-The report's RRPairs (carrying the HIT/MISS mock-match verdicts) land in &lt;out-directory&gt;/report-&lt;id&gt;/ and the source snapshot's recorded traffic in a sibling snapshot-&lt;id&gt;/ — exactly the two sides analyze_mock_matches needs, so this tool is step one of the mock match-rate tuning loop: pull_report -&gt; analyze_mock_matches -&gt; accept_mock_recommendation -&gt; repeat.
+The report's RRPairs (carrying the HIT/MISS mock-match verdicts) land in &lt;out-directory&gt;/report-&lt;id&gt;/ and the source snapshot's recorded traffic in a sibling snapshot-&lt;id&gt;/ — exactly the two sides the mocks tool needs, so this tool is step one of the mock match-rate tuning loop: pull_report -&gt; mocks action=analyze -&gt; mocks action=accept -&gt; repeat.
 
 Report ids come from the Speedscale dashboard's report URL, or from the user. Requires Speedscale cloud credentials (run 'proxymock init' once to register). Distinct from pull_remote_recording, which records fresh traffic by service and time range rather than fetching an existing replay report.
 


### PR DESCRIPTION
The replay-tuning guide (scripted `proxymock-replay-tuning` CLI, added in #708) and the mock-match-rate guide (AI agent plus MCP recommendations, added in #710) both shipped at `sidebar_position: 8` and covered overlapping ground. They collided in the sidebar and read as competing tutorials.

This PR positions them as a pair:

- **mock-match-rate** stays the flagship at `sidebar_position: 8` for the AI-agent auto-fix flow.
- **replay-tuning** moves to `9` as the scripted counterpart, documents the `--fail-under` CI gate, and keeps AI-assisted interpretation optional.
- Each guide links to the other so readers can choose the right workflow.
- The generated MCP reference and mock-match-rate guide use the grouped `mocks` tool from [speedscale!6661](https://gitlab.com/speedscale/speedscale/-/merge_requests/6661), while documenting the prior tool names as one-release deprecated aliases.

The MCP reference change depends on speedscale!6661. Merge that implementation before this documentation update.

Verified with the branch-built `proxymock mcp docs` output, `go test ./speedctl/mcp/...`, and a full Docusaurus production build.
