### PR TITLE
proxymock docs: group mock-tuning MCP tools under the mocks tool

### DIFF
--- a/docs/proxymock/guides/mock-match-rate.md
+++ b/docs/proxymock/guides/mock-match-rate.md
@@ -75,7 +75,7 @@ In your AI agent, from the `mock-lab/go` directory:
 /improve-mock-match-rate
 ```
 
-or in any MCP client: *"improve the mock match rate in this workspace"*. The agent runs `analyze_mock_matches`, which finds the two runs on its own (the recording is the mock source, the mock output is the request source) and reports:
+or in any MCP client: *"improve the mock match rate in this workspace"*. The agent runs the `mocks` tool with `action=analyze`, which finds the two runs on its own (the recording is the mock source, the mock output is the request source) and reports:
 
 ```text
 Report match rate:    ~40% — recorded verdicts
@@ -96,7 +96,7 @@ Recommendation groups (impact-sorted):
    - responder|body:variables.id  fix: variables.id -> constant
 ```
 
-The analyzer groups the misses by endpoint and recommends one fix per rotating value. On `/v1/track` it wildcards the rotating path segment and masks the body timestamp plus each time-anchored query id — the epoch, Snowflake, ObjectId, UUIDv7, xid, and KSUID are recognized because each embeds a timestamp that lands inside the recording's own capture window. On `/graphql` it masks only the rotating `variables.id` and leaves the `query`/`operationName` that identify the operation untouched. The agent accepts them with `accept_mock_recommendation`:
+The analyzer groups the misses by endpoint and recommends one fix per rotating value. On `/v1/track` it wildcards the rotating path segment and masks the body timestamp plus each time-anchored query id — the epoch, Snowflake, ObjectId, UUIDv7, xid, and KSUID are recognized because each embeds a timestamp that lands inside the recording's own capture window. On `/graphql` it masks only the rotating `variables.id` and leaves the `query`/`operationName` that identify the operation untouched. The agent accepts them with `mocks` `action=accept`:
 
 ```text
 Accepted all open recommendations: N filter-scoped chain(s) written into blueprint(s) responder Mocks.
@@ -106,7 +106,7 @@ Projected match rate: ~40% -> 100%.
 
 Exact totals scale with how much traffic you drive; the shape — one group per endpoint, one fix per rotating value — is what matters.
 
-For ambiguous misses the agent digs deeper with `similar_candidates`, which ranks a miss against the nearest recorded signatures and classifies each drifting field's cause (datetime, epoch, uuid, uuidv7, ulid, ksuid, xid, snowflake, objectid, jwt, trace-id, pii, opaque). The skill's playbook uses those causes to choose safely — e.g. a PII-classified lookup key gets `smart_replace_recorded` instead of a blind mask, and anything auth-shaped is surfaced to you rather than auto-accepted.
+For ambiguous misses the agent digs deeper with `mocks` `action=similar`, which ranks a miss against the nearest recorded signatures and classifies each drifting field's cause (datetime, epoch, uuid, uuidv7, ulid, ksuid, xid, snowflake, objectid, jwt, trace-id, pii, opaque). The skill's playbook uses those causes to choose safely — e.g. a PII-classified lookup key gets `smart_replace_recorded` instead of a blind mask, and anything auth-shaped is surfaced to you rather than auto-accepted.
 
 ## 4. Confirm with a real run
 
@@ -132,9 +132,11 @@ The agent pulls, analyzes, accepts fixes, and iterates exactly as above. When it
 | Tool | Role |
 | --- | --- |
 | `pull_report` | Pull a cloud replay report and its source snapshot into a local workspace |
-| `analyze_mock_matches` | Report + projected match rates, recommendation groups with accept ids, drift summary |
-| `accept_mock_recommendation` | Accept or undo a fix by id (or `all=true`); reports the rate movement inline |
-| `similar_candidates` | Per-miss deep dive: nearest recorded signatures and per-field drift causes |
+| `mocks` (`action=analyze`) | Report + projected match rates, recommendation groups with accept ids, drift summary |
+| `mocks` (`action=accept` / `action=undo`) | Accept or undo a fix by id (or `all=true`); reports the rate movement inline |
+| `mocks` (`action=similar`) | Per-miss deep dive: nearest recorded signatures and per-field drift causes |
+
+The prior standalone `analyze_mock_matches`, `accept_mock_recommendation`, and `similar_candidates` tools still work as deprecated aliases of `mocks` for one release.
 
 See the [MCP Tools & Prompts Reference](../how-it-works/mcp-tools.md) for full parameter documentation, and the [Replay Tuning guide](replay-tuning.md) for the script-based variant of this workflow.
 

--- a/docs/proxymock/how-it-works/mcp-tools.md
+++ b/docs/proxymock/how-it-works/mcp-tools.md
@@ -215,9 +215,33 @@ Accepting a transform recommendation merges its transform chains into the worksp
 | `id` | string | **yes** | Recommendation id as returned by list_recommendations. |
 | `action` | string | no | 'accept' (default) merges the recommendation into the tuning blueprint; 'reject' hides it from future lists. |
 
+#### `mocks`
+
+Tune a replay's OUTBOUND mock match rate offline, from RRPair files in one workspace — no replay or cluster needed. Select the operation with 'action':
+
+- 'analyze' (read-only): report how well the replay's outbound requests match the recorded mocks, and list impact-sorted fix recommendations grouped by the filter that would collapse them. Reports two rates over the same denominator — the report (ground-truth) rate recorded at replay time, and the projected rate with the workspace's active tuning blueprints applied.
+- 'accept' (writes blueprint): accept one recommendation by 'id' (from analyze), or every open one with 'all'=true. Writes a filter-scoped transform into the workspace's per-service tuning blueprint; no RRPair files are rewritten. The response reports the projected-rate movement immediately.
+- 'undo' (writes blueprint): remove a previously accepted recommendation by 'id'. Idempotent, so accepts and undos can be tried and reverted freely.
+- 'similar' (read-only): deep-dive one projected miss ('id'), ranking it against the recorded mock corpus with per-field drift, likely cause, and any pending recommendation — to reason about ambiguous misses before accepting fixes.
+
+The workspace usually comes from 'proxymock cloud pull report &lt;id&gt;', which materializes both analysis sides (snapshot-* and report-* run directories). This is the Mocks-view match-rate loop; it is a different id space from apply_recommendation, which handles general replay-tuning recommendations.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `action` | string | **yes** | Which mocks operation to run: 'analyze' and 'similar' are read-only; 'accept' and 'undo' write the tuning blueprint. |
+| `in-directory` | array | **yes** | Exactly one workspace directory holding both analysis sides as run directories (usually snapshot-* and report-*). The tuning blueprint is stored under it. |
+| `all` | boolean | no | action=accept only: accept every open recommendation with its default transform (the web UI's 'Accept all'). |
+| `id` | string | no | A recommendation id (shaped '&lt;service&gt;\|&lt;target&gt;') for action=accept/undo, or a projected-miss id for action=similar — both as returned by action=analyze. Required for accept (unless all=true), undo, and similar. |
+| `max` | number | no | action=similar only: how many nearest candidates to return (default 3). |
+| `mock-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the recorded mock signatures. Auto-discovered when omitted: the newest snapshot-*/recorded-*/mocked-* run. |
+| `request-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the outbound requests to check. Auto-discovered when omitted: the newest report-*/replayed-* run. |
+| `transform` | string | no | action=accept only: transform type overriding the recommendation's default (e.g. 'constant' to mask). Ignored for URL id-segment fixes, which always wildcard. |
+
 #### `analyze_mock_matches`
 
 _Read-only._
+
+DEPRECATED — use the `mocks` tool with action=analyze instead. This alias forwards to the same implementation and will be removed in a future release.
 
 Analyze how well a replay's outbound requests match the recorded mocks, and list tuning recommendations. Works entirely from RRPair files on disk — no replay or cluster needed. Reports two rates over the same outbound denominator:
 
@@ -235,6 +259,8 @@ The workspace usually comes from 'proxymock cloud pull report &lt;id&gt;', which
 | `request-source` | string | no | Optional run-directory name (or absolute RRPair directory) supplying the outbound requests to check. Auto-discovered when omitted: the newest report-*/replayed-* run. |
 
 #### `accept_mock_recommendation`
+
+DEPRECATED — use the `mocks` tool with action=accept|undo instead. This alias forwards to the same implementation and will be removed in a future release.
 
 Accept or undo one mock-match tuning recommendation by id (from analyze_mock_matches), or accept every open recommendation at once with all=true.
 
@@ -255,6 +281,8 @@ The response includes the projected match rate before and after the change, so t
 #### `similar_candidates`
 
 _Read-only._
+
+DEPRECATED — use the `mocks` tool with action=similar instead. This alias forwards to the same implementation and will be removed in a future release.
 
 Deep-dive on a single projected miss from analyze_mock_matches: rank it against the recorded mock corpus and explain, field by field, why the nearest recorded requests don't match.
 
@@ -415,7 +443,7 @@ Pull traffic from a remote service, including backend dependencies. Can accept e
 
 Pull a Speedscale cloud replay report AND the snapshot it was generated from into a local workspace — the equivalent of 'proxymock cloud pull report &lt;id&gt;'.
 
-The report's RRPairs (carrying the HIT/MISS mock-match verdicts) land in &lt;out-directory&gt;/report-&lt;id&gt;/ and the source snapshot's recorded traffic in a sibling snapshot-&lt;id&gt;/ — exactly the two sides analyze_mock_matches needs, so this tool is step one of the mock match-rate tuning loop: pull_report -&gt; analyze_mock_matches -&gt; accept_mock_recommendation -&gt; repeat.
+The report's RRPairs (carrying the HIT/MISS mock-match verdicts) land in &lt;out-directory&gt;/report-&lt;id&gt;/ and the source snapshot's recorded traffic in a sibling snapshot-&lt;id&gt;/ — exactly the two sides the mocks tool needs, so this tool is step one of the mock match-rate tuning loop: pull_report -&gt; mocks action=analyze -&gt; mocks action=accept -&gt; repeat.
 
 Report ids come from the Speedscale dashboard's report URL, or from the user. Requires Speedscale cloud credentials (run 'proxymock init' once to register). Distinct from pull_remote_recording, which records fresh traffic by service and time range rather than fetching an existing replay report.
 


### PR DESCRIPTION
## Problem

The proxymock mock-match-rate tuning tools were regrouped in the MCP server: the three standalone tools `analyze_mock_matches`, `accept_mock_recommendation`, and `similar_candidates` are now one grouped `mocks` tool with `action=analyze|accept|undo|similar` (they remain as deprecated aliases for one release). The rendered MCP reference and the mock-match-rate guide still named the old tools.

## Solution

- Regenerate `docs/proxymock/how-it-works/mcp-tools.md` from the new tool registry (`proxymock mcp docs` via `scripts/gen-mcp-docs.sh`): the `mocks` tool now appears with its `action` param, and the three old tools carry the DEPRECATED note.
- Update the `mock-match-rate.md` guide prose and tool table to reference `mocks` + actions, with a note that the old names still work as deprecated aliases.

Pairs with speedscale MR !6661 (the server-side change).