### PR TITLE
proxymock cluster commands: CLI reference and regenerated MCP tool reference

### DIFF
--- a/docs/proxymock/how-it-works/mcp-tools.md
+++ b/docs/proxymock/how-it-works/mcp-tools.md
@@ -454,22 +454,55 @@ Narrow the pull with a time window (from/to) and filters (service, namespace, st
 
 #### `cluster`
 
-Turn Speedscale eBPF traffic capture on and off for a Kubernetes workload, and read back whether it is on. Talks to the cluster your kubeconfig points at — no Speedscale account or registered inspector is needed. Select the operation with 'action':
+Work the Kubernetes cluster your kubeconfig points at: inspect what is running, turn Speedscale eBPF traffic capture on and off, and run recorded traffic back against a workload inside the cluster. Select the operation with 'action'.
 
-- 'inject' (mutates the cluster): turn capture on for one workload by patching its capture.speedscale.com/* annotations. eBPF capture attaches to running pods, so the workload is NOT restarted; setting 'java_agent' does restart it, because the agent is injected at pod admission and only loads into new pods. Idempotent.
-- 'uninject' (mutates the cluster): turn capture off for one workload by clearing those annotations. Idempotent, and already-recorded traffic is untouched.
+Capture — record real traffic off a running workload:
+- 'inject' (mutates): turn capture on for one workload by patching its capture.speedscale.com/* annotations. eBPF capture attaches to running pods, so the workload is NOT restarted; setting 'java_agent' does restart it, because the agent is injected at pod admission and only loads into new pods. Idempotent.
+- 'uninject' (mutates): turn capture off by clearing those annotations. Idempotent; already-recorded traffic is untouched.
 - 'capture-status' (read-only): report whether capture is on, whether the java agent is enabled, which ports are excluded, and whether the workload looks like it runs a JVM.
 
-These record intent: the in-cluster Speedscale operator and nettap daemon watch the annotations and perform the actual capture, so annotating a cluster without them installed has no effect. Use 'capture-status' first to see whether a workload is already captured, and to check 'javaDetected' before deciding on 'java_agent'.
+Replay — run recorded traffic against a workload in the cluster:
+- 'replay-prepare' (read-only, local): analyze recordings on this machine and return the inbound slices a replay can be routed at and the outbound dependencies it can mock. Runs the same analyzer the cloud runs, with no push and no login, so the keys it returns are exactly the keys 'replay-start' accepts. Call this before 'replay-start' rather than guessing dependency keys.
+- 'replay-start' (mutates, needs a Speedscale cloud login): push the recordings as a snapshot, wait for the cloud to analyze it, and create the replay. Give it either 'workload' (replay against a cluster workload — the only shape that can mock dependencies) or 'target' (replay against a plain address, touching nothing in the cluster). 'mocks' takes the outbound keys from 'replay-prepare'; mocking a dependency makes the responder answer it from the recording instead of letting the workload reach the real thing, which is what makes the replay repeatable. Returns immediately with the replay name and report id — it does not block.
+- 'replay-status' (read-only): with 'replay_name', the full stage breakdown of one replay including the operator's own explanation of a failure; without it, the replays currently running in the cluster (pass 'all' to include finished ones still present). A replay is garbage-collected after it finishes, so a long-completed replay will not be found — read its report in Speedscale cloud.
+- 'replay-logs' (read-only): the generator, responder and system-under-test log lines for a running replay. This is a LIVE tap with no history and is lossy under load, so it returns lines emitted while it is subscribed and nothing from before; it returns nothing for a replay that is not currently running. The complete log is the cloud report.
+- 'replay-cancel' (mutates, destructive): stop a running replay by deleting it. This reverts the workload under test and tears down the generator and responder, and produces no report. Refused once the generator has finished, so it cannot discard results that are still being analyzed.
+
+Inspect — read-only, and the fastest way to answer "what is actually in this cluster":
+- 'namespaces': the namespaces the forwarder has observed. Start here when you do not know what is in the cluster — but note it lists only namespaces nettap has seen traffic in, so it is not the same as 'kubectl get ns'.
+- 'nodes': the cluster's nodes with kernel, OS image and container runtime. The kernel version is what to check when eBPF capture records nothing.
+- 'services': the Services in a namespace with type, cluster IP and ports. A Service address is usually what 'replay-start' wants as its 'target'.
+- 'dependencies': the ConfigMaps, Secrets, Services and volumes one workload references and how it reaches each. This is the DECLARED wiring from the workload's spec, the complement to 'topology' (which shows connections actually observed). Names and reference paths only — no ConfigMap or Secret values are returned.
+- 'topology': the service map for one namespace — its workloads, the workloads elsewhere they exchange traffic with, and the observed connections between them. Built from what nettap sees on the wire, so it shows real connections, not declared ones.
+- 'workloads': the workloads the forwarder has observed, cluster-wide or in one namespace. These are the names 'inject' and 'replay-start' take.
+- 'pods': the pods in a namespace, optionally narrowed to one workload, with node, IP and phase. This is the OBSERVED inventory, not the apiserver's, so a freshly scaled-up workload can show fewer pods than 'kubectl get pods' — and fewer than 'logs' returns, since that reads the apiserver through the inspector.
+- 'logs': pod logs for a workload. Served by the in-cluster inspector under its own ServiceAccount, so this works even when the kubeconfig cannot read pod logs directly. Set 'previous' to read the last terminated container — the only way to see why a CrashLoopBackOff pod died.
+- 'events': Kubernetes events for a workload and its pods. Failed image pulls, scheduling problems, probe failures and OOM kills surface here first.
+
+Capture and inspect need only a kubeconfig; the inspect and replay actions also need the in-cluster speedscale-forwarder and speedscale-inspector, which this reaches by port-forwarding unless 'forwarder_addr' is set. Capture records intent only: the in-cluster operator and nettap daemon watch the annotations and do the actual capture, so annotating a cluster without them installed has no effect.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `action` | string | **yes** | Which cluster operation to run: 'capture-status' is read-only; 'inject' and 'uninject' patch annotations on the workload. |
-| `namespace` | string | **yes** | Kubernetes namespace holding the workload. |
-| `workload` | string | **yes** | Name of the workload to target. |
+| `action` | string | **yes** | Which cluster operation to run. Read-only: 'capture-status', 'replay-prepare', 'replay-status', 'replay-logs', 'topology', 'namespaces', 'nodes', 'workloads', 'pods', 'services', 'dependencies', 'logs', 'events'. Mutating: 'inject', 'uninject', 'replay-start', 'replay-cancel'. |
+| `all` | boolean | no | action=replay-status listing: include replays that are no longer running but are still in the cluster. |
+| `container` | string | no | action=logs: container to read within each pod. Omit for the pod's first container. |
+| `forwarder_addr` | string | no | Address of an already-reachable speedscale-forwarder gRPC port ('host:port'), used by 'topology', 'namespaces', 'nodes', 'workloads', 'pods' and 'replay-logs'. Omit to port-forward to it automatically. |
 | `ignore_ports` | string | no | action=inject only: comma-separated ports to exclude from capture (e.g. '8080,9090'). |
+| `in_directories` | array | no | action=replay-prepare and replay-start: directories holding the RRPair files to replay. Defaults to the working directory. |
+| `inspector_addr` | string | no | Address of an already-reachable speedscale-inspector HTTP port ('host:port'), used by 'logs', 'events', 'services' and 'dependencies'. Omit to port-forward to it automatically. |
 | `java_agent` | boolean | no | action=inject only: also inject the Java agent. Restarts the workload, and is only useful when 'capture-status' reports javaDetected. |
 | `kube_context` | string | no | Kubeconfig context to target. Omit to use the current-context. |
+| `limit` | number | no | action=events: keep only the most recent N events (default 50). action=replay-logs: stop after N lines (default 200). |
+| `mocks` | array | no | action=replay-start: outbound dependency keys to mock, taken verbatim from 'replay-prepare'. Only applies to a workload replay, because mocking needs a responder. |
+| `namespace` | string | no | Kubernetes namespace. Required for every action except 'replay-prepare', 'namespaces', 'nodes' and the cluster-wide listings ('workloads', 'replay-status'), where omitting it spans the cluster. |
+| `pod` | string | no | action=logs: read only this pod instead of every pod of the workload. |
+| `previous` | boolean | no | action=logs: read the last terminated container instead of the running one. This is how you find out why a CrashLoopBackOff pod died. |
+| `replay_name` | string | no | action=replay-status and replay-cancel: the replay's name as returned by 'replay-start' or listed by 'replay-status'. Omit on 'replay-status' to list instead. |
+| `report_id` | string | no | action=replay-logs: the report id 'replay-start' returned, which scopes the log tap to that replay. |
+| `snapshot_id` | string | no | action=replay-start: replay a snapshot already in Speedscale cloud instead of pushing the local recordings. |
+| `tail_lines` | number | no | action=logs: read only the last N lines of each pod log. |
+| `target` | string | no | action=replay-start: replay against this address instead of a cluster workload. Nothing in the cluster is modified and nothing can be mocked. Mutually exclusive with 'workload'. |
+| `workload` | string | no | Name of the workload to target. Required for the capture actions, 'logs', 'events' and 'dependencies'; on 'replay-start' it selects the system under test; on 'pods' it narrows the listing. List the options with action='workloads'. |
 | `workload_type` | string | no | Workload kind: deployment (default), statefulset, daemonset, replicaset, job or rollout. |
 
 ### Process control

--- a/docs/proxymock/how-it-works/mcp-tools.md
+++ b/docs/proxymock/how-it-works/mcp-tools.md
@@ -479,17 +479,15 @@ Inspect — read-only, and the fastest way to answer "what is actually in this c
 - 'logs': pod logs for a workload. Served by the in-cluster inspector under its own ServiceAccount, so this works even when the kubeconfig cannot read pod logs directly. Set 'previous' to read the last terminated container — the only way to see why a CrashLoopBackOff pod died.
 - 'events': Kubernetes events for a workload and its pods. Failed image pulls, scheduling problems, probe failures and OOM kills surface here first.
 
-Capture and inspect need only a kubeconfig; the inspect and replay actions also need the in-cluster speedscale-forwarder and speedscale-inspector, which this reaches by port-forwarding unless 'forwarder_addr' is set. Capture records intent only: the in-cluster operator and nettap daemon watch the annotations and do the actual capture, so annotating a cluster without them installed has no effect.
+Everything here needs only a kubeconfig. The inspect and replay actions are served by Speedscale components running in the cluster, which proxymock locates and port-forwards to for you using 'kube_context' — there is nothing to configure and no address to supply. Capture records intent only: the in-cluster operator and nettap daemon watch the annotations and do the actual capture, so annotating a cluster without them installed has no effect.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `action` | string | **yes** | Which cluster operation to run. Read-only: 'capture-status', 'replay-prepare', 'replay-status', 'replay-logs', 'topology', 'namespaces', 'nodes', 'workloads', 'pods', 'services', 'dependencies', 'logs', 'events'. Mutating: 'inject', 'uninject', 'replay-start', 'replay-cancel'. |
 | `all` | boolean | no | action=replay-status listing: include replays that are no longer running but are still in the cluster. |
 | `container` | string | no | action=logs: container to read within each pod. Omit for the pod's first container. |
-| `forwarder_addr` | string | no | Address of an already-reachable speedscale-forwarder gRPC port ('host:port'), used by 'topology', 'namespaces', 'nodes', 'workloads', 'pods' and 'replay-logs'. Omit to port-forward to it automatically. |
 | `ignore_ports` | string | no | action=inject only: comma-separated ports to exclude from capture (e.g. '8080,9090'). |
 | `in_directories` | array | no | action=replay-prepare and replay-start: directories holding the RRPair files to replay. Defaults to the working directory. |
-| `inspector_addr` | string | no | Address of an already-reachable speedscale-inspector HTTP port ('host:port'), used by 'logs', 'events', 'services' and 'dependencies'. Omit to port-forward to it automatically. |
 | `java_agent` | boolean | no | action=inject only: also inject the Java agent. Restarts the workload, and is only useful when 'capture-status' reports javaDetected. |
 | `kube_context` | string | no | Kubeconfig context to target. Omit to use the current-context. |
 | `limit` | number | no | action=events: keep only the most recent N events (default 50). action=replay-logs: stop after N lines (default 200). |

--- a/docs/reference/proxymock-cli-reference.md
+++ b/docs/reference/proxymock-cli-reference.md
@@ -531,11 +531,14 @@ straight to the cluster, so no Speedscale account or registered inspector is
 needed. The one exception is `cluster replay start`, which publishes the
 recordings to Speedscale Cloud so the in-cluster generator can pull them.
 
-Use `--kube-context` to pick a context other than your current one. Verbs served
-by an in-cluster Speedscale component reach it by port-forwarding; pass
-`--forwarder-addr` (topology, namespaces, nodes, workloads, pods, replay logs) or
-`--inspector-addr` (logs, events, services, dependencies) to point at an address
-you are already forwarding yourself.
+Use `--kube-context` to pick a context other than your current one. That is the
+only connection setting most people ever need: the read and replay verbs are
+served by Speedscale components running inside the cluster, and proxymock finds
+them and port-forwards to them for you.
+
+`--forwarder-addr` is available on the forwarder-served verbs for the narrow case
+where you are already running your own `kubectl port-forward`, or can reach the
+forwarder directly. It is never required.
 
 This is the same surface as the `cluster` MCP tool and the Observability view in
 `proxymock web`.

--- a/docs/reference/proxymock-cli-reference.md
+++ b/docs/reference/proxymock-cli-reference.md
@@ -24,6 +24,7 @@ proxymock [command]
 
 - `admin` - Administrative and maintenance commands (certs, clean)
 - `cloud` - Manage your Speedscale Cloud resources
+- `cluster` - Inspect and drive a Kubernetes cluster from the command line
 - `completion` - Generate the autocompletion script for the specified shell
 - `files` - Utilities for working with RRPair files
 - `generate` - Generate RRPair files from OpenAPI specification
@@ -522,6 +523,206 @@ proxymock cloud push [command]
 - `test-config` - Push a test config to Speedscale Cloud
 - `transform` - Push a transform set to Speedscale Cloud
 - `user-data` - Push user-defined documents
+
+## Kubernetes cluster commands
+
+These commands work the cluster your kubeconfig points at. Reads and writes go
+straight to the cluster, so no Speedscale account or registered inspector is
+needed. The one exception is `cluster replay start`, which publishes the
+recordings to Speedscale Cloud so the in-cluster generator can pull them.
+
+Use `--kube-context` to pick a context other than your current one. Verbs served
+by an in-cluster Speedscale component reach it by port-forwarding; pass
+`--forwarder-addr` (topology, namespaces, nodes, workloads, pods, replay logs) or
+`--inspector-addr` (logs, events, services, dependencies) to point at an address
+you are already forwarding yourself.
+
+This is the same surface as the `cluster` MCP tool and the Observability view in
+`proxymock web`.
+
+### `cluster`
+
+Inspect and drive a Kubernetes cluster from the command line.
+
+**Usage**
+
+```bash
+proxymock cluster [command]
+```
+
+**Available subcommands**
+
+- `capture` - Turn eBPF traffic capture on or off for a workload
+- `dependencies` - Show what a workload depends on
+- `events` - Read Kubernetes events for a workload
+- `logs` - Read pod logs for a workload
+- `namespaces` - List the namespaces the cluster's forwarder can see
+- `nodes` - List the cluster's nodes
+- `pods` - List the pods in a namespace
+- `replay` - Run a recorded snapshot against a workload inside the cluster
+- `services` - List the Kubernetes Services in a namespace
+- `topology` - Show the service map for a namespace
+- `workloads` - List the workloads the cluster's forwarder can see
+
+**Common flags**
+
+- `--kube-context string` - kubeconfig context to target (default: your current-context)
+- `-n, --namespace string` - Kubernetes namespace holding the workload
+- `--workload string` - workload name to target
+- `--workload-type string` - workload kind: deployment, statefulset, daemonset, replicaset, job or rollout
+
+### `cluster capture`
+
+Turn eBPF traffic capture on or off for a Kubernetes workload, and read back
+whether it is currently on. These verbs patch `capture.speedscale.com/*`
+annotations onto the workload, which records intent: the in-cluster Speedscale
+operator and nettap daemon watch those annotations and do the actual capture.
+
+**Usage**
+
+```bash
+proxymock cluster capture [command]
+```
+
+**Available subcommands**
+
+- `inject` - Turn eBPF traffic capture on for a workload
+- `status` - Report whether eBPF capture is on for a workload
+- `uninject` - Turn eBPF traffic capture off for a workload
+
+**Flags**
+
+- `--java-agent` - inject only: also inject the Java agent (restarts the workload; only useful for JVM workloads)
+- `--ignore-ports int32Slice` - inject only: ports to exclude from capture, comma separated
+
+**Examples**
+
+```bash
+# capture a deployment, leaving the health-check port out
+proxymock cluster capture inject -n banking-app --workload banking-user --ignore-ports 8080
+
+# check whether capture is on, and whether the workload runs a JVM
+proxymock cluster capture status -n banking-app --workload banking-user
+
+# turn it back off
+proxymock cluster capture uninject -n banking-app --workload banking-user
+```
+
+### `cluster replay`
+
+Run recorded traffic against a workload running in your cluster. The Speedscale
+operator provisions the generator that sends the traffic and, when you mock
+dependencies, the responder that answers them.
+
+**Usage**
+
+```bash
+proxymock cluster replay [command]
+```
+
+**Available subcommands**
+
+- `cancel` - Tear down a running replay
+- `logs` - Tail a running replay's logs
+- `prepare` - Show what a recording can route and what it can mock
+- `start` - Push the recordings and start a replay in the cluster
+- `status` - Report where a replay is, or list the running ones
+
+**Flags**
+
+- `--in strings` - directories holding the RRPair files to replay (prepare, start)
+- `--target string` - start: replay against this address instead of a cluster workload (no mocking)
+- `--route strings` - start: send one inbound slice to its own workload as `SLICE=WORKLOAD`; repeatable
+- `--mock strings` - start: outbound dependency key to mock, from `replay prepare`; repeatable
+- `--snapshot-id string` - start: replay a snapshot already in Speedscale Cloud instead of pushing these recordings
+- `--wait` - start: block until the replay reaches a terminal state, reporting each stage
+- `--all` - status: include replays that are no longer running but still in the cluster
+- `--source strings` - logs: only stream this component: generator, responder or collector
+- `-f, --follow` - logs: keep streaming until interrupted, ignoring `--timeout`
+- `--max-lines int` - logs: stop after this many lines
+
+**Examples**
+
+```bash
+# find out what can be routed and what can be mocked, locally and without a login
+proxymock cluster replay prepare --in proxymock
+
+# replay against a workload, mocking its database, and block until it finishes
+proxymock cluster replay start -n banking-app --workload banking-user \
+  --mock 'postgres:banking-postgres:5432' --wait
+
+# split the recording: one slice to its own workload, the rest to --workload
+proxymock cluster replay start -n banking-app --workload banking-frontend \
+  --route 'checkout:checkout.example.com:8080=banking-gateway'
+
+# what is running right now, then follow one
+proxymock cluster replay status
+proxymock cluster replay status -n banking-app quiet-otter-1234
+
+# stop one
+proxymock cluster replay cancel -n banking-app quiet-otter-1234
+```
+
+Every slice goes to exactly one destination. The operator rejects a replay whose
+workloads claim overlapping traffic.
+
+`replay logs` is a live tap with no history: it delivers lines emitted while it
+is subscribed, so start it while the replay is running. The complete log is the
+report in Speedscale Cloud.
+
+### `cluster` read commands
+
+Read-only views of the cluster, each the scriptable equivalent of a panel in the
+`proxymock web` Observability view. All support `-o json`.
+
+**Usage**
+
+```bash
+proxymock cluster namespaces
+proxymock cluster nodes
+proxymock cluster workloads [--namespace NS]
+proxymock cluster topology --namespace NS
+proxymock cluster pods --namespace NS [--workload NAME]
+proxymock cluster services --namespace NS
+proxymock cluster dependencies --namespace NS --workload NAME
+proxymock cluster logs --namespace NS --workload NAME [--container NAME] [--previous] [--tail N] [--since SECONDS]
+proxymock cluster events --namespace NS --workload NAME [--limit N]
+```
+
+Two different in-cluster services back these, and the difference is visible:
+
+- `topology`, `namespaces`, `nodes`, `workloads` and `pods` come from the
+  forwarder's aggregator, which only knows about what nettap has **observed**. A
+  workload or pod with no observed traffic is absent, so a freshly scaled-up
+  workload can show fewer pods here than `kubectl get pods`.
+- `logs`, `events`, `services` and `dependencies` come from the inspector, which
+  reads the apiserver under its own ServiceAccount. Those work for any workload,
+  observed or not, and work for a user whose own kubeconfig is not allowed to
+  read pod logs directly.
+
+**Examples**
+
+```bash
+# what is in this cluster
+proxymock cluster namespaces
+proxymock cluster workloads --namespace banking-app
+
+# what talks to what, from traffic actually seen on the wire
+proxymock cluster topology --namespace banking-app
+
+# why is this workload unhealthy
+proxymock cluster events -n banking-app --workload banking-user
+proxymock cluster logs -n banking-app --workload banking-user --previous
+
+# a pod stuck in init: read the init container the failure names
+proxymock cluster logs -n banking-app --workload banking-user \
+  --container speedscale-initproxy-responder
+```
+
+`--previous` reads the last terminated container, which is the only way to see
+why a `CrashLoopBackOff` pod died. When a read comes back empty the output names
+the pod's containers, including init containers, so you can pick the right one
+with `--container`.
 
 ## System commands
 


### PR DESCRIPTION
The `proxymock cluster` verbs were undocumented. The capture verbs shipped in [speedscale!6681](https://gitlab.com/speedscale/speedscale/-/merge_requests/6681) and the replay and read verbs in [speedscale!6685](https://gitlab.com/speedscale/speedscale/-/merge_requests/6685); neither reached the docs. The CLI reference had no `cluster` entry at all, and the MCP tool reference predates the `cluster` tool's replay and inspect actions.

## What changed

**`docs/reference/proxymock-cli-reference.md`** — new "Kubernetes cluster commands" section covering `cluster capture` (inject/uninject/status), `cluster replay` (prepare/start/status/logs/cancel) and the nine read verbs (topology, namespaces, nodes, workloads, pods, services, dependencies, logs, events), plus a `cluster` entry in the top-level command list.

**`docs/proxymock/how-it-works/mcp-tools.md`** — regenerated with `scripts/gen-mcp-docs.sh` from the binary's live tool registry, so the `cluster` tool's full action enum is documented rather than hand-copied.

## The distinction the section makes explicit

Two different in-cluster services back these verbs, and users will notice the difference before they notice the cause:

- `topology`, `namespaces`, `nodes`, `workloads`, `pods` read the forwarder's aggregator, which only knows what nettap has **observed** — a workload with no observed traffic is absent, so a freshly scaled-up deployment shows fewer pods than `kubectl get pods`.
- `logs`, `events`, `services`, `dependencies` read the inspector, which queries the apiserver under its own ServiceAccount, so they cover any workload and work for a user whose kubeconfig cannot read pod logs.

That means `cluster logs` can legitimately return pods `cluster pods` does not list. Verified on minikube while writing this.

## Checks

- `yarn build` passes.
- The added section is pure ASCII, matching the rest of the file.