### PR TITLE
proxymock v2.5.814 docs: cluster/BYOC/local-rule guides + CLI and MCP reference

### DIFF
--- a/docs/proxymock/guides/byoc-bucket.md
+++ b/docs/proxymock/guides/byoc-bucket.md
@@ -1,0 +1,93 @@
+---
+title: Pull Traffic from a BYOC Bucket
+description: "Bring-your-own-cloud keeps captured traffic in your own S3 bucket. Use proxymock import s3 or the pull_byoc_bucket MCP tool to pull historical traffic from that bucket into a local workspace you can search, mock, and replay, without the traffic leaving your account through Speedscale."
+sidebar_position: 14
+---
+
+# Pull Traffic from a BYOC Bucket
+
+In a bring-your-own-cloud (BYOC) deployment, captured traffic never leaves your account: the in-cluster Speedscale collector writes it to an object-store bucket you own, in your own cloud. proxymock pulls historical traffic from that bucket into a local workspace, so you can search, mock, and replay real production traffic without routing it through Speedscale.
+
+The pull runs entirely locally against your bucket. Credentials come from the standard AWS environment chain, and the traffic lands as ordinary RRPair files, so every proxymock workflow works on it unchanged.
+
+There are three ways to run the pull, over the same bucket layout:
+
+- **CLI** with `proxymock import s3`.
+- **MCP** with the `pull_byoc_bucket` tool, so an AI agent can fetch its own production context.
+- **Web** through the source picker in `proxymock web`.
+
+## How the bucket is laid out
+
+The BYOC OpenTelemetry `awss3` exporter writes OTLP-JSON objects under the `byoc/` prefix, in hive-style `year=/month=/day=/hour=/minute=` partitions. When the bucket contains `_speedscale/byoc-layout.json`, proxymock reads it to enumerate workload-specific `namespace=/app=/…` prefixes directly, which makes a narrow pull cheap. The legacy Fluent Bit layout, with objects at the bucket root and hour-granularity partitions, is also supported.
+
+Point `--prefix` at `byoc/` for the current layout. proxymock prunes the object listing by the time window before it downloads anything, so a tight `--from`/`--to` keeps the pull fast even against a large bucket.
+
+## Before you begin
+
+- `proxymock` [installed](../getting-started/quickstart/quickstart-cli.md).
+- Read access to the BYOC bucket, via the standard AWS credential chain: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, or an instance role. No Speedscale account or API key is required for the pull.
+
+## Pull with the CLI {#cli}
+
+Pull matching traffic from the last hour, narrowing by service and status:
+
+```shell
+proxymock import s3 --bucket my-bucket --prefix byoc/ \
+  --filter '(service IS "checkout") AND (status IS "500")'
+```
+
+The `--filter` string uses the Speedscale [traffic filter language](/reference/filters/structure.md). Convenience flags (`--from`, `--to`, `--service`, `--endpoint`, `--status`, `--namespace`, `--direction`, `--trace-id`) are added only when the filter does not already cover that criterion; where they overlap, the filter wins. `--status` is an exact match and `--endpoint` is a substring match, so use `--filter` for anything more specific.
+
+The imported RRPairs land in `proxymock/imported-s3-<timestamp>/` by default. From there, replay or mock them like any recording:
+
+```shell
+proxymock replay --in ./proxymock/imported-s3-<timestamp> --test-against http://localhost:8080
+```
+
+### Test the layout with a local directory
+
+`--local-dir` reads from a local directory tree with the same layout as a BYOC bucket, which is useful for air-gapped work and for testing a pull without touching S3. When it is set, `--bucket` and AWS credentials are not used:
+
+```shell
+proxymock import s3 --local-dir ./fixtures/byoc-traffic --prefix byoc/ --service checkout --limit 10
+```
+
+### Redact on the way in
+
+Pass `--dlp-config` to apply a local DLP config to matched RRPairs before they are written to disk, so sensitive values never land in your workspace unredacted. This is the air-gap-friendly path: the redaction happens locally, against a rule you author locally.
+
+```shell
+proxymock import s3 --bucket my-bucket --prefix byoc/ --from now-15m --dlp-config my-dlp.json
+```
+
+See [Author DLP and filter rules locally](./local-rules.md) for how to build and test that config.
+
+### Keep pulling as traffic arrives
+
+`--follow` keeps the import running, re-listing the bucket for new objects until you interrupt it. Tune the cadence with `--poll-interval` (default `30s`):
+
+```shell
+proxymock import s3 --bucket my-bucket --prefix byoc/ --service checkout --follow
+```
+
+### S3-compatible stores
+
+For MinIO, DigitalOcean Spaces, or another S3-compatible store, set `--s3-endpoint-url` and usually `--s3-force-path-style`. Set `--region` when the SDK cannot infer it. The full flag list is in the [CLI reference](/reference/proxymock-cli-reference.md#import-s3).
+
+## Pull with the MCP tool {#mcp}
+
+The `pull_byoc_bucket` MCP tool gives an AI coding assistant the same pull. It runs locally with no Speedscale account; credentials come from the AWS environment chain. Describe what you need and the assistant fills in the parameters:
+
+> Pull the last 15 minutes of checkout 500s from the `my-bucket` BYOC bucket and replay them against my local build.
+
+The tool takes `bucket` plus the same narrowing parameters as the CLI (`prefix`, `from`, `to`, `service`, `namespace`, `status`, `trace-id`, or a full `filter`), returns the import summary, and writes RRPair files to `./proxymock/imported-s3-<timestamp>/`. This is distinct from `pull_remote_recording`, which pulls from Speedscale-managed cloud; use `pull_byoc_bucket` when the traffic lives in your own bucket. See the [MCP Tools reference](../how-it-works/mcp-tools.md) for the full parameter list.
+
+## Pull from proxymock web {#web}
+
+In `proxymock web`, the import source picker offers a BYOC bucket as a source alongside local files. Give it the bucket, prefix, and a time window, and the imported run appears in the Run selector like any other recording, ready to explore in the Requests grid or replay.
+
+## Next steps
+
+- [Author DLP and filter rules locally](./local-rules.md) redacts or trims the pulled traffic before you use it.
+- [Explore and Replay Sessions Locally](./sessions.md) walks the record-and-replay loop the imported traffic feeds into.
+- [Fix Replay Failures with Recommendations](./recommendations.md) correlates rotating values so imported traffic replays cleanly.

--- a/docs/proxymock/guides/cluster.md
+++ b/docs/proxymock/guides/cluster.md
@@ -1,0 +1,131 @@
+---
+title: Work a Kubernetes Cluster from the CLI
+description: "Use the proxymock cluster verbs to turn eBPF traffic capture on and off for a workload, run a recorded replay inside the cluster, and read topology, pod logs, and Kubernetes events, all from your kubeconfig. The same surface is available as the cluster MCP tool and the proxymock web Observability view."
+sidebar_position: 13
+---
+
+# Work a Kubernetes Cluster from the CLI
+
+`proxymock cluster` drives the Kubernetes cluster your kubeconfig points at without leaving the terminal. It turns eBPF traffic capture on and off for a workload, runs a recorded replay inside the cluster, and reads the service map, pod logs, and Kubernetes events.
+
+This is the same surface three ways: the `cluster` verbs here, the grouped `cluster` MCP tool (one tool with an `action` for each verb, so an AI agent can drive it), and the [Topology and cluster visibility](./observability.md) view in `proxymock web`. Pick whichever fits the task; they read and write the same cluster state.
+
+## How proxymock reaches the cluster
+
+Two kinds of connection are in play, and they need different access:
+
+- **Capture verbs write straight to the cluster from your kubeconfig.** `cluster capture` patches `capture.speedscale.com/*` annotations onto a workload. That needs no Speedscale account and no registered inspector; it records intent, and the in-cluster Speedscale operator and nettap daemon do the actual capture when they see the annotations.
+- **Read verbs are served by Speedscale components running in the cluster.** proxymock finds the in-cluster forwarder and inspector and port-forwards to them using the selected kube-context. That is automatic and needs no configuration. The topology-style reads come from the forwarder's aggregator; logs, events, services, and dependencies come from the inspector.
+
+`cluster replay start` is the one verb that also needs a Speedscale cloud login, because the in-cluster generator replays a snapshot pulled from the cloud rather than from local files. Every other verb runs from your kubeconfig alone.
+
+Use `--kube-context` on any verb to target a context other than your current one:
+
+```shell
+proxymock cluster topology --namespace banking-app --kube-context my-other-context
+```
+
+The workload flags are shared across the verbs that target one workload: `-n/--namespace` (default `default`), `--workload`, and `--workload-type` (one of `deployment`, `statefulset`, `daemonset`, `replicaset`, `job`, or `rollout`, default `deployment`).
+
+## Turn capture on and off {#capture}
+
+`cluster capture` controls eBPF capture for a single workload and reports its current state.
+
+```shell
+# turn capture on for a deployment
+proxymock cluster capture inject --namespace banking-app --workload banking-gateway
+
+# check whether capture is on
+proxymock cluster capture status -n banking-app --workload banking-gateway
+
+# turn capture off
+proxymock cluster capture uninject -n banking-app --workload banking-gateway
+```
+
+eBPF capture attaches to running pods, so `inject` does not restart the workload. `status` reads the annotations back and reports whether capture is on, whether the Java agent is enabled, which ports are excluded, and whether the workload looks like it runs a JVM. That JVM guess comes from the pod template and is advisory: it only tells you whether `--java-agent` would do anything.
+
+Two flags shape what gets captured:
+
+- `--ignore-ports` leaves ports out of capture, for example a health-check port: `--ignore-ports 8080,9090`.
+- `--java-agent` also injects the Java agent for JVM workloads. Unlike eBPF injection, this **restarts the workload**, because the agent is added by the admission webhook and only loads into pods created after the change.
+
+`inject` is idempotent, and it clears any conflicting `sidecar.speedscale.com/*` annotations first so the two capture modes never coexist. Annotating a cluster that has no operator or nettap installed has no effect: the annotations record intent, and something in the cluster has to act on them.
+
+## Replay a recording inside the cluster {#replay}
+
+`cluster replay` runs recorded traffic against a workload from inside the cluster. The Speedscale operator provisions the generator that sends the traffic and, when you mock dependencies, the responder that answers them.
+
+Start with `prepare`. It analyzes local recordings with the same analyzer the cloud uses and prints the two lists a replay is configured from, entirely offline:
+
+```shell
+proxymock cluster replay prepare --in ./proxymock/recorded-2026-07-22
+```
+
+- **inbound** slices are the traffic that can be routed at a target.
+- **outbound** dependencies are what can be mocked.
+
+The keys it prints are exactly the keys `start` accepts, so run `prepare` first to find out what to pass.
+
+`start` pushes the selected recordings to Speedscale cloud as a snapshot and creates the `TrafficReplay` that runs them in the cluster. Pick exactly one destination shape:
+
+```shell
+# replay against a workload, mocking its database
+proxymock cluster replay start -n banking-app --workload banking-user \
+  --mock 'postgres:banking-postgres:5432'
+
+# replay against a plain address, and block until it finishes
+proxymock cluster replay start --target http://banking-frontend.banking-app:80 --wait
+```
+
+- `--workload NAME` replays against a workload in the cluster. Only this shape can mock dependencies, and only this shape reports on the workload's own behavior.
+- `--target URL` replays against a single address. Nothing in the cluster is modified and nothing is mocked.
+
+`--mock` takes an outbound dependency key from `prepare`; repeat it to mock more than one. Mocking a dependency makes the responder answer it from the recording instead of letting the workload reach the real thing, which is what makes a replay repeatable. `--route SLICE=WORKLOAD` splits the recording so one inbound slice goes to its own workload; every slice goes to exactly one destination. To reuse a snapshot already in the cloud, pass `--snapshot-id` instead of pushing again.
+
+Watch and tear down a running replay with the remaining verbs:
+
+```shell
+proxymock cluster replay status          # where a replay is, or what is running now
+proxymock cluster replay logs            # tail the generator, responder, and SUT logs
+proxymock cluster replay cancel          # tear a running replay down
+```
+
+## Read topology, logs, and events {#read}
+
+The read verbs are for troubleshooting a workload without switching to `kubectl`. They target a namespace or a single workload and take the same `-o/--output` formats as the rest of the CLI (`pretty`, `json`, `yaml`, `csv`).
+
+```shell
+# the service map for a namespace
+proxymock cluster topology --namespace banking-app
+
+# list what the forwarder and cluster see
+proxymock cluster workloads -n banking-app
+proxymock cluster pods -n banking-app
+proxymock cluster services -n banking-app
+proxymock cluster nodes
+proxymock cluster namespaces
+
+# a workload's dependencies, logs, and events
+proxymock cluster dependencies -n banking-app --workload banking-user
+proxymock cluster logs -n banking-app --workload banking-frontend --tail 50 --since 300
+proxymock cluster events -n banking-app --workload banking-user
+```
+
+`logs` reads every pod of a workload by default; narrow it with `--pod`, pick a container with `--container`, and read a crashed container's last output with `--previous` (the only way to see why a `CrashLoopBackOff` pod died). Because logs are served by the in-cluster inspector under its own ServiceAccount, this works even when your own kubeconfig cannot read pod logs directly.
+
+### One distinction that trips people up
+
+The two backends see the cluster differently, and it is worth knowing which verb reads which:
+
+- **Topology-style reads come from the forwarder's aggregator**, built from what nettap has observed on the wire. They show real connections rather than declared ones, so a workload nettap has not seen any traffic for will not appear.
+- **Logs, events, services, and dependencies come from the inspector**, which reads the apiserver.
+
+So a freshly scaled workload can legitimately show fewer pods in the topology than in `pods` or `services`: nettap has not observed traffic to the new pods yet, but the apiserver already lists them. This is expected, not a bug.
+
+`topology` accepts `--forwarder-addr` as a narrow escape hatch when you are already port-forwarding to a forwarder yourself; leave it unset and proxymock does the port-forward for you.
+
+## Next steps
+
+- [Topology and cluster visibility](./observability.md) walks the same reads in `proxymock web`, with the workload drawer and Resources views.
+- [Explore and Replay Sessions Locally](./sessions.md) covers the local record-and-replay loop the in-cluster replay is built on.
+- The [proxymock CLI reference](/reference/proxymock-cli-reference.md#kubernetes-cluster-commands) lists every `cluster` flag, and the [MCP Tools reference](../how-it-works/mcp-tools.md) documents the `cluster` tool's actions.

--- a/docs/proxymock/guides/local-rules.md
+++ b/docs/proxymock/guides/local-rules.md
@@ -1,0 +1,115 @@
+---
+title: Author DLP and Filter Rules Locally
+description: "Build and test DLP redaction rules, traffic filters, and transforms against local RRPair files with no cloud, no API key, and no network. The rule is the same JSON document Speedscale Cloud uses, so it round-trips through cloud pull and push. Available as CLI verbs, MCP tools, and web editors."
+sidebar_position: 15
+---
+
+# Author DLP and Filter Rules Locally
+
+Redaction and filter rules decide what leaves your environment and what gets kept. proxymock lets you author and test those rules against RRPair files on your own machine, with no Speedscale account, no API key, and no network access. That is what makes the air-gap story honest: you can prove exactly what a rule redacts or drops before any traffic moves anywhere.
+
+Three rule kinds share the same local workflow:
+
+- **DLP** redacts sensitive values out of traffic.
+- **Filter** keeps or drops whole RRPairs.
+- **Transform** rewrites values in place, for example re-signing a JWT or shifting a timestamp.
+
+Each is available three ways: as a CLI verb (`proxymock dlp`, `proxymock filter`, `proxymock transform`), as an MCP tool (the `dlp` and `config` tools), and as an editor in `proxymock web`. Whichever you use, the config is the **same JSON document Speedscale Cloud uses**, so a rule authored locally uploads with `proxymock cloud push`, and a cloud rule tests locally after `proxymock cloud pull`. The engines match too: the DLP pipeline is identical to what `proxymock record --dlp-config` applies at capture time, the filter engine is the one the forwarder runs, and the transform engine is the one the cloud Transforms tab and the responder apply at replay. What you see locally is what runs in production.
+
+## Before you begin
+
+- `proxymock` [installed](../getting-started/quickstart/quickstart-cli.md).
+- A directory of RRPair files to test against, for example a `recorded-*` run or an [imported BYOC pull](./byoc-bucket.md).
+- A rule to test. Write one by hand, or start from a cloud rule: `proxymock cloud pull dlp standard` writes the shipped `standard` DLP rule to disk. Pulling needs an account; testing and applying do not.
+
+## Redact with DLP {#dlp}
+
+`dlp test` reports what a config would redact without changing any file: per-location match counts, and the file and location of each match. Run it against a recording to see what a rule catches:
+
+```shell
+# report what a rule would redact
+proxymock dlp test --dlp-config my-dlp.json --in ./recorded
+
+# test a rule downloaded with 'proxymock cloud pull dlp standard'
+proxymock dlp test --dlp-config standard --in ./recorded
+
+# inspect the full before/after redaction of one file
+proxymock dlp test --dlp-config my-dlp.json --show-redacted ./recorded/api/foo.md
+```
+
+Because `dlp test` runs the same pipeline as capture-time redaction, its report is exactly what a live recording with `--dlp-config` would produce. Iterate on the JSON until the match counts cover the values you care about and nothing you need.
+
+When the rule is right, `dlp apply` writes redacted copies to a separate directory. The input files are never modified, and `--out` must be outside `--in`:
+
+```shell
+proxymock dlp apply --dlp-config my-dlp.json --in ./recorded --out ./redacted
+```
+
+You can also redact at the moment traffic enters your workspace. `proxymock import s3 --dlp-config` applies the rule to matched RRPairs before they are written, so sensitive values from a [BYOC pull](./byoc-bucket.md) never touch disk unredacted, and `proxymock record --dlp-config` redacts at capture time.
+
+## Keep or drop with filters {#filter}
+
+A filter classifies each RRPair: one that matches the filter is dropped, one that does not is kept. `filter test` reports the split without writing anything:
+
+```shell
+# report which RRPairs would be kept or dropped
+proxymock filter test --filter-config my-filter.json --in ./recorded
+
+# list every dropped RRPair, not just a sample
+proxymock filter test --filter-config my-filter.json --in ./recorded --show-dropped
+```
+
+`filter apply` writes only the RRPairs the filter keeps to a new directory:
+
+```shell
+proxymock filter apply --filter-config my-filter.json --in ./recorded --out ./filtered
+```
+
+The filter config uses the Speedscale [traffic filter language](/reference/filters/structure.md), the same expressions the forwarder evaluates in-cluster.
+
+## Rewrite values with transforms {#transform}
+
+Transforms change values rather than dropping records: re-signing a JWT, rotating a message id, shifting a timestamp into the replay window. `transform test` previews the change, `transform apply` writes transformed copies:
+
+```shell
+# preview what a transform set would change
+proxymock transform test --transform-config my-transforms.json --in ./recorded
+
+# show the full before/after of one file
+proxymock transform test --transform-config my-transforms.json --show ./recorded/api/foo.md
+```
+
+For the transform language and the built-in transform library, see [Transforms](/guides/transformation/overview.md). Many transforms can be generated for you instead of hand-written: [Recommendations](./recommendations.md) detects rotating values and writes the transform chains automatically.
+
+## From an AI agent (MCP) {#mcp}
+
+The same authoring loop is available to an AI coding assistant, so it can build and check its own redaction and filter rules:
+
+- The **`dlp`** tool takes an `action` of `test` or `apply`, plus the config path and input directories. `test` is read-only; `apply` writes redacted copies.
+- The **`config`** tool covers filters and transforms with an `action` of `filter-test`, `transform-test`, or `transform-apply`. The two `-test` actions are read-only previews; `transform-apply` writes transformed copies. To write only the RRPairs a filter keeps, use the `proxymock filter apply` CLI command.
+
+Both tools run offline and read and write the same JSON documents as `proxymock cloud pull/push`, so a rule an agent authors round-trips to Speedscale Cloud unchanged. See the [MCP Tools reference](../how-it-works/mcp-tools.md) for the full parameters.
+
+## From proxymock web {#web}
+
+`proxymock web` ships editors for DLP and filter rules. Load a run, author the rule against its traffic, and preview what it redacts or drops before you save. The saved rule is the same JSON the CLI and MCP paths read, so you can start a rule in the browser and finish it on the command line, or the reverse.
+
+## Round-trip to Speedscale Cloud {#round-trip}
+
+Local authoring and cloud enforcement are two ends of the same rule:
+
+```shell
+# pull a cloud rule, refine it locally, push it back
+proxymock cloud pull dlp standard
+proxymock dlp test --dlp-config standard --in ./recorded
+# edit the JSON, re-test, then:
+proxymock cloud push dlp
+```
+
+The same `pull`/`push` pair works for `filter` and `transform`. Author where it is fastest to iterate, prove the behavior against real RRPairs, and enforce the identical rule in the cluster.
+
+## Next steps
+
+- [Pull Traffic from a BYOC Bucket](./byoc-bucket.md) is the natural source of traffic to redact and filter.
+- [Fix Replay Failures with Recommendations](./recommendations.md) generates transform chains for rotating values.
+- The [proxymock CLI reference](/reference/proxymock-cli-reference.md#local-rule-authoring-commands) lists every flag for `dlp`, `filter`, and `transform`.

--- a/docs/proxymock/guides/mock-match-rate.md
+++ b/docs/proxymock/guides/mock-match-rate.md
@@ -143,6 +143,25 @@ The standalone `analyze_mock_matches`, `accept_mock_recommendation`, and `simila
 
 See the [MCP Tools & Prompts Reference](../how-it-works/mcp-tools.md) for full parameter documentation, and the [Replay Tuning guide](replay-tuning.md) for the script-based variant of this workflow.
 
+## From the command line
+
+Every step the agent runs through the `mocks` tool is also a `proxymock match-rate` verb, over the same workspace and the same blueprints. The analysis and the ids are identical, so you can drive the loop by hand or wire it into a script when you would rather not involve an agent:
+
+```shell
+# report the match rate and list fixes (add -o json to script it)
+proxymock match-rate analyze
+
+# accept one fix by id, or accept everything the analyzer found
+proxymock match-rate accept --id 'responder|url:/v1/track/*'
+proxymock match-rate accept --all
+
+# undo a fix, or deep-dive one projected miss
+proxymock match-rate undo --id 'responder|url:/v1/track/*'
+proxymock match-rate similar --id proxymock/report-.../responder/abc123.md
+```
+
+`accept` writes the same filter-scoped transforms into the workspace's tuning blueprint that the agent would, and `--transform` lets you override the recommended fix for one id (for example `--transform constant`). When the workspace came from a cloud report, `proxymock cloud pull report <id>` materializes both analysis sides first, exactly as `pull_report` does for the agent. The full flag list is in the [CLI reference](/reference/proxymock-cli-reference.md#match-rate).
+
 ## Good to know
 
 - Fixes are **blueprint-only** — no RRPair files are rewritten, and every accept can be undone.

--- a/docs/proxymock/guides/recommendations.md
+++ b/docs/proxymock/guides/recommendations.md
@@ -101,6 +101,26 @@ Everything the recommendation did is visible and editable in the **Blueprints** 
 
 You are not limited to accepting recommendations — you can author the same kind of rule by hand. In a request's detail, click the transform icon on a header or query field (or right-click a body field) to add a transform straight onto that field; proxymock saves it as a blueprint just like a recommendation does. See [Modifying Tests/Mocks](./modify-rrpairs.md#applying-transforms-in-proxymock-web) for that field-level workflow, and switch the Requests grid to the **Preview blueprints** lens to walk a before/after of every change the active blueprints make before you replay.
 
+## Work recommendations from the command line
+
+The web panel is one of three ways to work the same findings. `proxymock recommendations` runs the identical analyzer over the RRPair files in a workspace and writes the same blueprints, so you can skip `proxymock web` and script the loop instead. After a replay, from the parent of `proxymock/`:
+
+```shell
+# analyze and list what the analyzer found, with an id for each
+proxymock recommendations list
+
+# only the mechanical transform fixes (the ones that fix replay failures)
+proxymock recommendations list --type transform
+
+# accept one recommendation into the workspace's tuning blueprint
+proxymock recommendations accept --id 3f9a1c2e8b7d4056
+
+# hide a recommendation you do not want offered again
+proxymock recommendations reject --id 3f9a1c2e8b7d4056
+```
+
+`accept` merges the recommendation's transform chains into the blueprint on disk, exactly as clicking **Accept** in the panel does; no RRPair files are rewritten, and later replay and mock runs apply the blueprint automatically. The same loop is available to an AI agent through the `recommendations` MCP tool. This is a different id space from `proxymock match-rate`, which works the outbound mock match-rate fixes covered in [Improve Mock Match Rate](./mock-match-rate.md). The full flag list is in the [CLI reference](/reference/proxymock-cli-reference.md#recommendations).
+
 ## How this relates to the credentials swap
 
 | Your recording carries… | Use… |

--- a/docs/proxymock/how-it-works/mcp-tools.md
+++ b/docs/proxymock/how-it-works/mcp-tools.md
@@ -44,8 +44,12 @@ Start the mock server with RRPairs from the mock files in the directory.
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `in-directory` | array | **yes** | Directories containing the mock RRPair files. Directories are read recursively. Usually these directories end with 'proxymock' and are contained in the current repository. |
+| `fault` | array | no | Repeatable '&lt;regexp&gt;:action=value[,action=value...]' specs. Rate alone injects intermittent 503s; body=corrupt\|truncate\|truncate:&lt;bytes&gt; returns a well-formed shorter body; connection=refuse\|reset\|stall\|drop faults the socket (drop cuts the stream mid-response). |
 | `log-to` | string | no | File path to redirect all proxymock output to |
+| `mock-reload-interval` | string | no | Hot-reload check interval such as '1s'. Omit to disable. |
+| `mock-timing` | string | no | Response timing: 'none', 'recorded', or a multiplier such as '5x'. |
 | `out-directory` | array | no | Directories to write new mock request/response files to. MATCH, NO_MATCH, AND PASSTHROUGH seen by mock server. If not provided, defaults to a timestamped directory. Unless otherwise instructed use 'proxymock/mocked-&lt;date&gt;' where &lt;date&gt; is the output from the command 'date +%Y-%m-%d_%H-%M-%S', or something similar. |
+| `response-selection` | string | no | Duplicate-signature response selection: 'round-robin' (default) or weighted-by-copy-count 'random'. |
 
 #### `mock_server_stop`
 
@@ -59,7 +63,7 @@ _No parameters._
 
 Replay recorded RRPairs from test files against an HTTP server URL.
 
-By default each request is replayed once, which acts as a regression test. To run a performance / load test instead, set 'vus' (concurrency) together with 'for' (run for a duration) or 'times' (run a number of iterations), and optionally 'performance' mode for high-throughput runs. Use 'fail-if' to encode a pass/fail condition such as a latency budget.
+By default each request is replayed once, which acts as a regression test. To run a performance / load test instead, set 'vus' (concurrency) together with 'for' (run for a duration) or 'times' (run a number of iterations), and optionally 'load-test' mode for high-throughput runs. Use 'fail-if' to encode a pass/fail condition such as a latency budget.
 
 The replay runs in the background: use the list_running tool to see when it finishes and the read_process_logs tool to inspect results, including whether any 'fail-if' condition triggered. After completion, run the generate_report tool on the output directory for latency percentiles and quality scores.
 
@@ -69,8 +73,8 @@ The replay runs in the background: use the list_running tool to see when it fini
 | `out-directory` | array | **yes** | Directories to write observed replay request/response files to. Unless otherwise instructed use 'proxymock/replayed-&lt;date&gt;' where &lt;date&gt; is the output from the command 'date +%Y-%m-%d_%H-%M-%S', or something similar. |
 | `fail-if` | string | no | Condition expression that marks the replay as failed (exit code 1) when true, e.g. 'latency.p99 &gt; 100' or 'requests.result-match-pct &lt; 95.5'. Check the process logs to see whether the condition triggered. |
 | `for` | string | no | How long to run the replay, as a Go duration string (e.g. '30s', '5m'). Traffic is replayed continuously, on a loop, until the duration expires. Mutually exclusive with 'times'. Omit both to replay each request exactly once. |
+| `load-test` | boolean | no | Load test mode only writes a sample of failed or non-matching requests to disk, trading granular data collection for replay speed. Recommended for high-throughput load tests (many vus or long durations). Responses are not scored, so 'requests.result-match-pct' is not reported and cannot be used in 'fail-if'. When the app runs behind 'proxymock mock', start the mock without an output directory. |
 | `log-to` | string | no | File path to redirect all proxymock output to |
-| `performance` | boolean | no | Performance mode only writes a sample of failed or non-matching requests to disk, trading granular data collection for replay speed. Recommended for high-throughput load tests (many vus or long durations). |
 | `rewrite-host` | boolean | no | Rewrite the HTTP Host header to match the target hostname:port. Set this when the target server routes requests by Host header (e.g. virtual hosts, ingress controllers). |
 | `test-against` | string | no | A partial or full URL which will override some or all of the captured URL during replay. If not provided, the target depends on the traffic. The test-against address may be a full or partial URL which will override the base URL of requests during replay. - If a scheme is provided the scheme of the request will be replaced - If a hostname is provided the hostname of the request will be replaced - If a port is provided the port of the request will be replaced Example test-against addresses: \| Captured URL \| Test Against \| Replay URL \|-----------------------------\|---------------------\|----------- \|https://original.com:443/foo \| http://new.com:8080 \| http://new.com:8080/foo \|https://original.com:443/foo \| http:// \| http://original.com:443/foo \|https://original.com:443/foo \| http://new.com \| http://new.com:443/foo \|https://original.com:443/foo \| new.com \| https://new.com:443/foo \|https://original.com:443/foo \| new.com:8080 \| https://new.com:8080/foo \|https://original.com:443/foo \| :8080 \| https://original.com:8080/foo \|https://original.com:443/foo \| http://:8080 \| http://original.com:8080/foo |
 | `times` | number | no | Number of times to replay the full traffic set (default 1). Mutually exclusive with 'for'. |
@@ -268,15 +272,18 @@ The 'config' is the same JSON document 'proxymock cloud pull/push dlp' read and 
 
 #### `edit_rrpair`
 
-Replace the request or response body of an RRPair markdown file in the local workspace. Content-Length on the edited side is recomputed automatically and the file is rewritten atomically.
+Edit an HTTP RRPair markdown file: request or response body and headers, response status code, and duration metadata. Content-Length is recomputed after body edits and the file is rewritten atomically.
 
-Use this to fix stale recorded data before mocking or replaying, e.g. after search_local_traffic or compare_rrpair_files points you at the file. Only .md RRPair files are editable.
+Use this to fix stale recorded data before mocking or replaying, e.g. after search_local_traffic or compare_rrpair_files points you at the file. Relative and absolute paths are accepted; both must resolve inside the working directory. Only existing .md RRPair files are editable.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `file` | string | **yes** | Path to the .md RRPair file, relative to the working directory, e.g. 'proxymock/recorded-2026-01-01/my-host/rr.md'. |
-| `side` | string | **yes** | Which body to replace: 'request' or 'response'. |
-| `body` | string | **yes** | The new body content as a UTF-8 string. For binary content prefix with 'base64:' followed by standard base64. An empty string clears the body. |
+| `file` | string | **yes** | Relative or absolute path to the .md RRPair file. |
+| `body` | string | no | The new body content as a UTF-8 string. For binary content prefix with 'base64:' followed by standard base64. An empty string clears the body. |
+| `duration-ms` | number | no |  |
+| `headers` | object | no | Header names mapped to a string or array of strings. A null value deletes the header. Names are matched case-insensitively and stored lowercased, so the same header cannot be listed twice under different casing. |
+| `side` | string | no | Side whose body or headers to edit. Required when body or headers is supplied. |
+| `status-code` | number | no | Response status code. The reason phrase is derived from it — a custom phrase cannot be stored. |
 
 #### `delete_rrpairs`
 

--- a/docs/reference/proxymock-cli-reference.md
+++ b/docs/reference/proxymock-cli-reference.md
@@ -23,21 +23,32 @@ proxymock [command]
 ## Top-level commands
 
 - `admin` - Administrative and maintenance commands (certs, clean)
+- `automation` - Run a proxymock web automation headlessly
 - `cloud` - Manage your Speedscale Cloud resources
 - `cluster` - Inspect and drive a Kubernetes cluster from the command line
 - `completion` - Generate the autocompletion script for the specified shell
+- `dlp` - Author and validate DLP redaction rules against local RRPair files
+- `drift` - Find values that vary across two or more RRPair directories
+- `export` - Export recorded traffic to a 3rd party format
 - `files` - Utilities for working with RRPair files
+- `filter` - Author and validate filter rules against local RRPair files
 - `generate` - Generate RRPair files from OpenAPI specification
 - `help` - Help about any command
-- `import` - Import traffic from a snapshot file
+- `import` - Import traffic from a snapshot file or a BYOC S3 bucket
 - `init` - Initializes proxymock installation and configuration
 - `inspect` - Inspect Speedscale traffic (test / mock files)
+- `match-rate` - Tune the outbound mock match rate of a replay, offline
 - `mcp` - Model Context Protocol (MCP) server
 - `mock` - Run the mock server to respond to outbound requests from your app
+- `recommendations` - Work the replay-tuning recommendations the analyzer finds
 - `record` - Record traffic from your app, turning it into RRPair files
 - `replay` - Replay tests to make requests to your app
+- `report` - Generate a performance/reliability/security report from captured RRPairs
 - `send-one` - Send a single test (RRPair) to an arbitrary URL
+- `transform` - Author and validate traffic transforms against local RRPair files
+- `validate` - Validate recorded HTTP responses against an OpenAPI spec
 - `version` - Prints current version of client and cloud
+- `web` - Start the embedded web interface
 
 ## Main workflow commands
 
@@ -307,13 +318,23 @@ proxymock generate --include-optional api-spec.yaml
 
 ### `import`
 
-Import traffic from a snapshot file.
+Import traffic from a Speedscale snapshot file, or from a third-party capture format with the subcommands below. Each subcommand writes RRPair files into your local workspace.
 
 **Usage**
 
 ```bash
 proxymock import [flags]
+proxymock import [command]
 ```
+
+**Subcommands**
+
+- `import s3` - Import historical traffic from a BYOC S3 bucket (see below)
+- `import har` - Import a HAR document into local RRPair files
+- `import postman` - Import a Postman collection into local RRPair files
+- `import wiremock` - Import a WireMock project into local RRPair files
+- `import goreplay` - Import a GoReplay capture file into local RRPair files
+- `import http-wire` - Import raw HTTP wire format files into local RRPair files
 
 **Examples**
 
@@ -329,6 +350,58 @@ proxymock import --file /path/to/snapshot.json --out some/local/path
 
 - `--file string` - File to import into the proxymock repository
 - `--out string` - Directory where imported RRPair files will be written (default `proxymock/imported-<filename>`)
+- `-o, --output string` - Console output format, one of `pretty`, `json`, `yaml`, or `csv` (default `json`)
+
+### `import s3`
+
+Import historical BYOC traffic from a customer's own S3 bucket into a local proxymock directory. The BYOC OpenTelemetry `awss3` exporter writes objects under the `byoc/` prefix in hive-style `year=/month=/day=/hour=/minute=` partitions; proxymock reads `_speedscale/byoc-layout.json` when present to enumerate workload-specific prefixes directly, and the legacy Fluent Bit layout is also supported. Use `--local-dir` to read from a local directory tree with the same layout, in which case `--bucket` and AWS credentials are not used. See the [Pull traffic from a BYOC bucket](/proxymock/guides/byoc-bucket.md) guide for the full workflow.
+
+**Usage**
+
+```bash
+proxymock import s3 [flags]
+```
+
+**Examples**
+
+```bash
+# import matching traffic from the last hour
+proxymock import s3 --bucket my-bucket --prefix byoc/ \
+  --filter '(service IS "checkout") AND (status IS "500")'
+
+# import from a local directory with the same layout as the S3 bucket
+proxymock import s3 --local-dir ./fixtures/byoc-traffic --prefix byoc/ --service checkout --limit 10
+
+# redact matched traffic on the way in with a local DLP config
+proxymock import s3 --bucket my-bucket --prefix byoc/ --from now-15m --dlp-config my-dlp.json
+```
+
+**Flags**
+
+- `--bucket string` - S3 bucket containing BYOC traffic
+- `--local-dir string` - Local directory with BYOC S3 layout; mutually exclusive with `--bucket`
+- `--prefix string` - S3 key prefix to search; use `byoc/` for the current OTel `awss3` layout
+- `--filter string` - Speedscale traffic filter string; overlapping criteria override the convenience flags below
+- `--from string` - Start time when `--filter` has no timerange, e.g. `now-15m` or `2026-06-12T18:00:00Z` (default `now-1h`)
+- `--to string` - End time when `--filter` has no timerange (default `now`)
+- `--service strings` - Service filter (repeat or comma-separate) added when `--filter` has no service predicate
+- `--endpoint string` - Endpoint/location substring filter added when `--filter` has no endpoint predicate
+- `--status string` - Exact status filter added when `--filter` has no status predicate
+- `--direction string` - Direction filter (`in` or `out`) added when `--filter` has no direction predicate
+- `--namespace string` - Namespace filter added when `--filter` has no namespace predicate
+- `--app-label string` - Kubernetes app label used to narrow BYOC layout prefixes
+- `--trace-id string` - Trace ID filter added when `--filter` has no trace-related predicate
+- `--dlp-config string` - Local DLP config JSON file to apply to matched RRPairs before writing
+- `--limit int` - Maximum number of matched RRPairs to write; `0` means unlimited
+- `-f, --follow` - Keep importing as new objects arrive; runs until interrupted
+- `--poll-interval duration` - How often to re-list the source for new objects when `--follow` is set (default `30s`)
+- `--concurrency int` - Maximum number of S3 objects to download and parse concurrently (default `16`)
+- `--region string` - AWS region; defaults to the AWS SDK configuration
+- `--s3-endpoint-url string` - Custom S3 endpoint URL for S3-compatible stores
+- `--s3-force-path-style` - Use path-style S3 addressing
+- `--out string` - Directory where imported RRPair files will be written (default `proxymock/imported-s3-<timestamp>`)
+- `--out-format string` - Output format for files, one of `markdown` or `json` (default `markdown`)
+- `--timeout duration` - Command timeout, e.g. `10s`, `5m`, `1h` (default `12h`)
 - `-o, --output string` - Console output format, one of `pretty`, `json`, `yaml`, or `csv` (default `json`)
 
 ### `send-one`
@@ -351,6 +424,175 @@ proxymock send-one path/to/test.json http://orders:8080/foo/bar
 **Flags**
 
 - `-h, --help` - help for send-one
+
+## Replay tuning commands
+
+These commands tune a replay offline, from RRPair files on disk. No replay run, cluster, or Speedscale account is needed. They accept the same `-o/--output` formats as the rest of the CLI. `match-rate` and `recommendations` are separate id spaces: `match-rate` works the Mocks-view outbound match-rate fixes, `recommendations` works the general replay-tuning findings. Both write filter-scoped transforms into the workspace's per-service tuning blueprint rather than rewriting RRPair files, and later replay and mock runs apply the blueprint automatically.
+
+### `match-rate`
+
+Report and improve the rate at which a replay's outbound requests match the recorded mocks. This is the same loop as the web UI's Mocks view and the MCP `mocks` tool, over the same workspace and blueprints. The workspace usually comes from `proxymock cloud pull report <id>`, which materializes both analysis sides as run directories. See [Improve Mock Match Rate with AI](/proxymock/guides/mock-match-rate.md) for the guided workflow.
+
+**Subcommands**
+
+- `match-rate analyze` - Report the match rate and list fix recommendations
+- `match-rate accept` - Accept a recommendation into the tuning blueprint
+- `match-rate undo` - Remove a previously accepted recommendation
+- `match-rate similar` - Deep-dive one projected miss against the recorded mocks
+
+**Examples**
+
+```bash
+# report the match rate and list fixes in the current workspace
+proxymock match-rate analyze
+
+# analyze a pulled report, naming both sides explicitly
+proxymock match-rate analyze --in ./my-app \
+  --mock-source snapshot-2026-07-01 --request-source report-2026-07-02
+
+# accept one fix, or everything the analyzer found
+proxymock match-rate accept --id 'my-service|body:payment.transaction_id'
+proxymock match-rate accept --all
+
+# undo a previously accepted fix
+proxymock match-rate undo --id 'my-service|body:payment.transaction_id'
+
+# rank one projected miss against the nearest recorded signatures
+proxymock match-rate similar --id proxymock/report-2026-07-02/my-service/abc123.md --max 10
+```
+
+**Common flags**
+
+- `--in string` - Workspace directory holding the traffic to analyze (default `.`)
+- `--mock-source string` - Run directory supplying the recorded mock signatures (default: newest `snapshot-*`/`recorded-*`/`mocked-*` run)
+- `--request-source string` - Run directory supplying the outbound requests to check (default: newest `report-*`/`replayed-*` run)
+- `--id string` - Recommendation id (from `match-rate analyze`), shaped `<service>|<target>`; for `similar`, a projected-miss id
+- `--all` - (`accept`) Accept every open recommendation with its default transform
+- `--transform string` - (`accept`) Override the recommended transform for this id, e.g. `constant`
+- `--max int` - (`similar`) How many nearest recorded candidates to return (default `3`)
+- `-o, --output string` - Console output format, one of `pretty`, `json`, `yaml`, or `csv` (default `json`)
+
+### `recommendations`
+
+Analyze the RRPair files in a workspace and work the general replay-tuning recommendations the analyzer finds. `transform` recommendations are mechanical fixes the traffic needs to replay or mock cleanly (JWT re-signing, timestamp shifting, message-id rotation, data redaction); `traffic` recommendations are informational findings. Accepting merges a recommendation's transform chains into the workspace's per-service tuning blueprint. See [Fix Replay Failures with Recommendations](/proxymock/guides/recommendations.md) for the guided workflow.
+
+**Subcommands**
+
+- `recommendations list` - Analyze and list what the analyzer found, with the id needed to accept or reject each one
+- `recommendations accept` - Merge a recommendation's transforms into the blueprint
+- `recommendations reject` - Hide a recommendation from future lists
+
+**Examples**
+
+```bash
+# list everything the analyzer finds in the current directory
+proxymock recommendations list
+
+# only the mechanical transform fixes, from another workspace
+proxymock recommendations list --in ./my-app --type transform
+
+# accept or reject one recommendation by id
+proxymock recommendations accept --id 3f9a1c2e8b7d4056
+proxymock recommendations reject --id 3f9a1c2e8b7d4056
+```
+
+**Common flags**
+
+- `--in string` - Workspace directory holding the traffic to analyze (default `.`)
+- `--type string` - (`list`) Restrict to one kind: `transform` or `traffic`
+- `--id string` - Recommendation id to accept or reject (from `recommendations list`)
+- `-o, --output string` - Console output format, one of `pretty`, `json`, `yaml`, or `csv` (default `json`)
+
+## Local rule authoring commands
+
+Author and validate DLP redaction rules, traffic filters, and transforms against local RRPair files. These commands run entirely on your local system: no Speedscale configuration, API key, or network access is required. Each config is the same JSON document Speedscale Cloud uses, so a rule developed locally can be uploaded with `proxymock cloud push <kind>` and a cloud rule can be tested locally after `proxymock cloud pull <kind>`. The `--dlp-config`, `--filter-config`, and `--transform-config` flags each accept a JSON file path or the id of a rule downloaded with the matching `cloud pull`. See [Author DLP and filter rules locally](/proxymock/guides/local-rules.md) for the guided workflow.
+
+### `dlp`
+
+Author and validate DLP (data loss prevention) redaction rules. The redaction pipeline is identical to what `proxymock record --dlp-config` applies at capture time, so `dlp test` reports exactly what a live recording would redact.
+
+**Subcommands**
+
+- `dlp test` - Report what a DLP config would redact from RRPair files, without modifying any file
+- `dlp apply` - Write redacted copies of RRPair files
+
+**Examples**
+
+```bash
+# report per-field match counts and locations
+proxymock dlp test --dlp-config my-dlp.json --in ./recorded
+
+# test a rule previously downloaded with 'proxymock cloud pull dlp standard'
+proxymock dlp test --dlp-config standard --in ./recorded
+
+# show the full before/after redaction of one file
+proxymock dlp test --dlp-config my-dlp.json --show-redacted ./recorded/api/foo.md
+
+# write redacted copies to a separate directory
+proxymock dlp apply --dlp-config my-dlp.json --in ./recorded --out ./redacted
+```
+
+**Flags**
+
+- `--dlp-config string` - DLP config JSON file, or the id of a rule downloaded with `proxymock cloud pull dlp`
+- `--in strings` - Directories or RRPair files to read from (default `.`)
+- `--show-redacted string` - (`test`) Print the full before/after redaction of this RRPair file instead of the summary
+- `--out string` - (`apply`) Directory to write redacted copies to (must be outside `--in`)
+
+### `filter`
+
+Author and validate filter rules. The filter engine is identical to the one the forwarder uses: an RRPair that matches the filter is dropped, one that does not is kept.
+
+**Subcommands**
+
+- `filter test` - Report which RRPairs a filter would keep or drop
+- `filter apply` - Write only the RRPairs a filter keeps
+
+**Examples**
+
+```bash
+# report which RRPairs would be kept or dropped
+proxymock filter test --filter-config my-filter.json --in ./recorded
+
+# list every dropped RRPair, not just a sample
+proxymock filter test --filter-config my-filter.json --in ./recorded --show-dropped
+
+# write only the passing RRPairs to a separate directory
+proxymock filter apply --filter-config my-filter.json --in ./recorded --out ./filtered
+```
+
+**Flags**
+
+- `--filter-config string` - Filter config JSON file, or the id of a rule downloaded with `proxymock cloud pull filter`
+- `--in strings` - Directories or RRPair files to read from (default `.`)
+- `--show-dropped` - (`test`) List every dropped RRPair instead of a sample
+- `--out string` - (`apply`) Directory to write the passing RRPairs to (must be outside `--in`)
+
+### `transform`
+
+Author and validate traffic transforms. The transform engine is identical to the one the cloud snapshot Transforms tab and proxymock web use, so `transform test` previews exactly what the generator and responder would apply at replay.
+
+**Subcommands**
+
+- `transform test` - Preview what a transform config would change in RRPair files
+- `transform apply` - Write transformed copies of RRPair files
+
+**Examples**
+
+```bash
+# preview what a transform set would change
+proxymock transform test --transform-config my-transforms.json --in ./recorded
+
+# show the full before/after of one file
+proxymock transform test --transform-config my-transforms.json --show ./recorded/api/foo.md
+```
+
+**Flags**
+
+- `--transform-config string` - Transform config JSON file, or the id of a set downloaded with `proxymock cloud pull transform`
+- `--in strings` - Directories or RRPair files to read from (default `.`)
+- `--show string` - (`test`) Print the full before/after transform of this RRPair file instead of the summary
+- `--out string` - (`apply`) Directory to write transformed copies to (must be outside `--in`)
 
 ## File management commands
 


### PR DESCRIPTION
Catches the proxymock docs up to the CLI/MCP/web parity work merged since the reference pages last moved (docs trailed the feature set through v2.5.789). Verified against the installed v2.5.814 binary and a full `npm run build` (which runs with `onBrokenLinks: "throw"`, so every internal link and anchor resolves and there are no MDX parse errors).

## New guides

| Guide | Covers | Plan feature |
|---|---|---|
| `guides/cluster.md` — Work a Kubernetes Cluster from the CLI | `cluster capture inject/uninject/status`, `cluster replay prepare/start/status/logs/cancel`, and the read verbs (`topology/workloads/pods/nodes/services/dependencies/logs/events`); CLI + `cluster` MCP tool + web Observability; the forwarder-vs-inspector distinction | F17, F18, F19 |
| `guides/byoc-bucket.md` — Pull Traffic from a BYOC Bucket | CLI `import s3` (bucket and `--local-dir`), MCP `pull_byoc_bucket`, web source picker; air-gap framing and redact-on-import | BYOC bucket pull |
| `guides/local-rules.md` — Author DLP and Filter Rules Locally | `dlp`/`filter`/`transform` test+apply, the `dlp` and `config` MCP tools, the web editors (!6702), the `cloud pull`/`push` round-trip; air-gap framing | Filter/Transform/DLP authoring |

## Updated pages

- **`reference/proxymock-cli-reference.md`** — new sections for `match-rate`, `recommendations`, `dlp`, `filter`, `transform`, and `import s3`; completed the top-level command index (was missing `automation`, `dlp`, `drift`, `export`, `filter`, `match-rate`, `recommendations`, `report`, `transform`, `validate`, `web`).
- **`guides/mock-match-rate.md`** — added the CLI path (`proxymock match-rate analyze/accept/undo/similar`) alongside the existing MCP `mocks` flow.
- **`guides/recommendations.md`** — added the CLI path (`proxymock recommendations list/accept/reject`) alongside the existing web flow.
- **`how-it-works/mcp-tools.md`** — regenerated from the v2.5.814 binary via `scripts/gen-mcp-docs.sh`. Picks up mock `fault` injection, `mock-timing` and `response-selection`, the replay `performance` → `load-test` rename, and the expanded `edit_rrpair` (headers, status code, duration). Confirmed 29 tools, grouped registry, no removed alias names, `cluster` tool present with its actions.

## Notes

- **Release notes are out of scope by design.** `reference/release-notes.md` is autogenerated ("do not modify manually") and produced per-version by the pipeline ("Update release notes for v2.5.XXX"). The v2.5.789 entry already lists the match-rate/recommendations verbs and the MCP alias removal; the v2.5.814 entry lands via that same process, not a hand edit here.
- `how-it-works/cli.md` is a conceptual overview that defers all verb enumeration to the CLI reference, so it needed no per-verb changes.
- New guides wire into the sidebar automatically via the autogenerated `_category_.json` and `sidebar_position` frontmatter.
- MCP accuracy checked against the live registry: the `config` tool exposes `filter-test`/`transform-test`/`transform-apply` (filter *apply* is CLI-only), and `pull_byoc_bucket` is distinct from `pull_remote_recording`.
