### PR TITLE
Document blueprint discovery and load-vs-applied reporting

### DIFF
--- a/docs/proxymock/how-it-works/workspace-layout.md
+++ b/docs/proxymock/how-it-works/workspace-layout.md
@@ -63,6 +63,33 @@ and so on) created through the web UI or CLI. Blueprints are applied as an
 overlay at replay time; deleting this directory loses your saved transforms but
 not your recordings.
 
+`replay` and `mock` look for blueprints in the directory you pass to `--in` and
+in its immediate parent, under either `blueprints/` or `proxymock/blueprints/`,
+plus the machine-wide `~/.speedscale/data/transforms/`. The walk stops at the
+parent, so a `blueprints/` directory two or more levels above `--in` is not
+found. Every blueprint that applies is named on startup along with the file it
+came from:
+
+```
+Loaded blueprint "mock-lab smart replace (token + order_id)" from proxymock/blueprints/mocklab-smart-replace.json
+```
+
+Loaded is not the same as applied. A blueprint's chains only run against traffic
+its filters match, and replay rewrites each request's address to whatever
+`--test-against` names — so a filter on `network_address` is matched against the
+target you pass, not the address in the recording. A chain filtered on
+`localhost` does nothing when you replay against `127.0.0.1`. At the end of a
+replay each loaded blueprint reports how many of its chains ran:
+
+```
+Blueprint "mock-lab smart replace (token + order_id)": 2 transform chain(s) ran.
+```
+
+A blueprint that ran none is called out as a warning. Pass
+`--require-blueprint <name>` to turn that into a non-zero exit, which is what
+you want in CI. Blueprint reporting is unavailable under `--load-test`, which
+drops the transform events the count is derived from.
+
 ### `dataframes/`
 Payloads referenced by transforms — for example the CSV a `csv_dataframe`
 transform draws values from, stored at `dataframes/<id>/payload.csv`. Removing a


### PR DESCRIPTION
Blueprint discovery was undocumented, and the console gave no way to tell a blueprint that was doing work from one that had never been found. That combination cost a full engineering day of debugging and produced two contradictory sets of written conclusions.

Adds to the workspace-layout `blueprints/` section:

- where `replay` and `mock` actually look — the `--in` dir and its immediate parent, under either `blueprints/` or `proxymock/blueprints/`, plus `~/.speedscale/data/transforms/` — and that the walk stops at the parent
- that loading is not applying: chain filters are matched against the request **as replayed**, and replay rewrites the address to `--test-against`, so a filter on `localhost` does nothing against `127.0.0.1`
- the per-blueprint chain count printed at the end of a replay, the warning when a blueprint ran nothing, `--require-blueprint` for CI, and the `--load-test` exception

Pairs with the CLI change in speedscale/speedscale!6727, which adds the reporting this describes. Worth landing after that ships so the docs and the binary agree.