### PR TITLE
Document alternatives for Helm-restricted installations

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -49,6 +49,12 @@ If you are running Speedscale on your local desktop, you should continue directl
 
 If you are using a common Kubernetes distribution (EKS, GKE, minikube, etc) then you can install using these instructions. If you are not running in Kubernetes, or are running with a more specialized enterprise distribution please select environment-specific [instructions](./installation/install/README.md) in this section.
 
+:::info Cannot deploy a Helm chart?
+Helm does not need to run in your cluster. You can render the chart to plain Kubernetes YAML with `helm template`, commit the output to your GitOps repository, or use it as a Kustomize base. See the **GitOps** tab below for an example.
+
+If your organization cannot use Helm tooling at all, [contact Speedscale Support](mailto:support@speedscale.com), ask in the [Speedscale Community](https://slack.speedscale.com), or reach out to your account team. We can help produce Kustomize-compatible or other custom manifests for your cluster policies.
+:::
+
 <Tabs>
 
 <TabItem value="helm" label="Helm" default>
@@ -156,6 +162,15 @@ helm template speedscale-operator speedscale/speedscale-operator \
 ```
 
 Then store `speedscale-operator.yaml` in git so it is deployed to your cluster.
+
+The rendered file can also be referenced as a Kustomize resource:
+
+```yaml title="kustomization.yaml"
+resources:
+  - speedscale-operator.yaml
+```
+
+Re-render the manifest when upgrading Speedscale so chart changes and image versions stay current. If your policies prohibit Helm tooling even for offline rendering, [contact Speedscale Support](mailto:support@speedscale.com) for a Kustomize-compatible or custom manifest.
 
 </TabItem>
 

--- a/docs/reference/ebpf-traffic-collection/README.md
+++ b/docs/reference/ebpf-traffic-collection/README.md
@@ -125,6 +125,12 @@ the ingest/proxy side only needs raw socket access.
 
 ## Installation
 
+:::info Helm-restricted environments
+The eBPF collector is installed as Kubernetes resources, so Helm does not need to run in the cluster. You can render the Speedscale chart to plain YAML with `helm template` and manage the result directly or as a Kustomize base; see the [GitOps installation example](/getting-started/quick-start#install-speedscale-operator-optional).
+
+If your organization cannot use Helm tooling at all, [contact Speedscale Support](mailto:support@speedscale.com), ask in the [Speedscale Community](https://slack.speedscale.com), or reach out to your account team. We can help create Kustomize-compatible or other custom manifests with the required eBPF DaemonSet, RBAC, configuration, and cluster-specific settings.
+:::
+
 ### Enabling via Helm
 
 To enable eBPF capture, set `ebpf.enabled: true` in your Helm values and define at least one capture target:

--- a/docs/reference/helm.md
+++ b/docs/reference/helm.md
@@ -7,6 +7,12 @@ sidebar_position: 8
 
 This document describes the configuration options available for the Speedscale Operator Helm [chart](https://github.com/speedscale/operator-helm). The Speedscale Operator is a Kubernetes operator that watches for deployments and can inject proxies to capture traffic or set up isolation test environments.
 
+:::info Alternative manifest workflows
+If cluster policy prevents direct Helm deployments, render the chart to plain Kubernetes YAML with `helm template`, then manage that output directly or as a Kustomize base. The [GitOps quick-start example](/getting-started/quick-start#install-speedscale-operator-optional) shows this workflow.
+
+If Helm tooling is prohibited entirely, [contact Speedscale Support](mailto:support@speedscale.com), ask in the [Speedscale Community](https://slack.speedscale.com), or reach out to your account team for help creating Kustomize-compatible or other custom manifests.
+:::
+
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)


### PR DESCRIPTION
## Summary

- explain how to render the operator chart as plain Kubernetes YAML
- show how to use the rendered manifest as a Kustomize base
- invite customers who cannot use Helm tooling to contact Speedscale for tailored manifests
- add the guidance to the Kubernetes quick start, eBPF installation, and Helm reference

## Validation

- `yarn build`