### PR TITLE
Make capture guidance eBPF-first

### DIFF
--- a/docs/concepts/schedules.md
+++ b/docs/concepts/schedules.md
@@ -43,6 +43,10 @@ use an existing snapshot, or one created from a previous action.
 
 ### Sidecar
 
+:::warning Legacy capture action
+The Sidecar action applies only to existing sidecar deployments. New Kubernetes installations should use [eBPF capture](/reference/ebpf-traffic-collection) and control recording windows through capture targets or the `capture.speedscale.com/enabled` annotation.
+:::
+
 Ensures the Speedscale sidecar exists, or does not exist, on a workload running
 in your cluster.  A workload must have the sidecar attached to capture traffic.
 This action is useful for ensuring a workload is capturing traffic, or turning
@@ -66,7 +70,7 @@ work is performed in between actions.
 ### Notify
 
 Sends a notification when the action is reached during execution. Place this
-action anywhere in the sequence — for example, at the end to report the overall
+action anywhere in the sequence, for example at the end to report the overall
 outcome, or immediately after a replay to alert on test failures.
 
 #### Trigger conditions
@@ -104,7 +108,7 @@ To pass additional headers (for example, an authorization token) use the
 
 #### Message template
 
-Some services — including Slack — require a specific JSON shape and will reject
+Some services, including Slack, require a specific JSON shape and will reject
 the default payload. Set the **Message template** field to a
 [Go template](https://pkg.go.dev/text/template) string; when present the
 request body becomes `{"text": "<rendered>"}` instead.
@@ -143,7 +147,7 @@ Available template variables:
    For failure details you can iterate over `FailedTasks`:
 
    ```
-   *{{.JobID}}* failed — {{range .FailedTasks}}task {{.Index}}: {{.Message}} {{end}}
+   *{{.JobID}}* failed: {{range .FailedTasks}}task {{.Index}}: {{.Message}} {{end}}
    ```
 
 Slack validates that the posted JSON contains a `text` field and returns
@@ -157,5 +161,3 @@ Combine the Notify action with **On failure** and `continue_on_failure` enabled
 to get an alert any time a scheduled replay misses its goals without stopping
 the rest of the job.
 :::
-
-

--- a/docs/concepts/transforms.md
+++ b/docs/concepts/transforms.md
@@ -13,7 +13,17 @@ Automatically modify traffic before or during a replay.
 
 In order to replay properly, most apps require traffic to contain up to date JWTs, timestamps and more. Speedscale provides a general purpose data transformation system very similar to Unix pipes for this purpose.
 
-![Data is extracted, transformed and re-inserted into the RRPair](./transforms/diagram.png)
+```mermaid
+flowchart LR
+    rrpair["RRPair"] --> extractor["Extractor"]
+    extractor --> transform1["Transform 1"]
+    transform1 --> transform2["Transform 2"]
+    transform2 --> more["..."]
+    more --> transform2
+    transform2 --> transform1
+    transform1 --> extractor
+    extractor --> rrpair
+```
 
 First, data is extracted from the [RRPair](/reference/glossary.md#rrpair) using an **Extractor**. For example, an extractor might pull the value of a particular HTTP header in an request. Extractors always produce a string that can be further transformed. The extracted string is called a **token** throughout this documentation.
 
@@ -23,7 +33,18 @@ Transforms also have a data cache where **variables** can be stored. Variables f
 
 Last, the transformed data is re-inserted into the RRPair in exactly the same location. Each transform runs in reverse order to re-encode the new **token** and place it back in its correct place.
 
-![Concrete example of two transforms](./transforms/diagram_with_data.png)
+```mermaid
+flowchart LR
+    subgraph rrpair["RRPair"]
+        header["Record-Timestamp:<br/>Sat, 20 Nov 2019 07:16:26 GMT"]
+        body["order-id: 52-3059"]
+    end
+
+    header --> extractHeader["Extract header"] --> dateOffset["Date offset"]
+    dateOffset --> extractHeader --> header
+    body --> extractJson["Extract JSON"] --> insertText["Insert text"]
+    insertText --> extractJson --> body
+```
 
 ## Where to Transform Traffic
 
@@ -114,7 +135,7 @@ If you need more of a "global replace" functionality you should use variables fr
 
 ### Embedded
 
-Variable values — and several special keywords — can be embedded within other transform
+Variable values and several special keywords can be embedded within other transform
 configuration fields using the `${{...}}` syntax. The simplest form replaces a placeholder with the
 value of a variable (if known) wherever it is found in the transform configuration. For example, you
 may want to embed a variable inside of a constant to produce `new_value=<some value from variable 1>`:

--- a/docs/getting-started/installation/install/cloudrun.md
+++ b/docs/getting-started/installation/install/cloudrun.md
@@ -16,13 +16,29 @@ such as EKS and GKE.
 
 ## Working with Google Cloud Run
 
-![Architecture](./cloudrun/arch.png)
+```mermaid
+flowchart LR
+    client["Client / Internet"] --> inbound["goproxy inbound"]
+    inbound --> app["Cloud Run service"]
+    app --> outbound["goproxy outbound"]
+    outbound --> dependencies["Service dependencies"]
+
+    subgraph gke["GKE cluster"]
+        inbound
+        outbound
+        forwarder["Forwarder"]
+        inbound --> forwarder
+        outbound --> forwarder
+    end
+
+    forwarder --> cloud["Speedscale Cloud"]
+```
 
 In order to capture traffic from Cloud Run, we need to set up a few components shown in the diagram above.
 
 ### Create a cluster
 
-We need to create a GKE cluster in order to run our proxy and forwarding components. Follow the prompts in the Google Cloud console to create a standard GKE cluster. Do not create an Autopilot cluster for this setup — if you specifically need Autopilot, follow the [GKE Autopilot guide](/getting-started/installation/install/gke-autopilot) instead. All other standard settings should be fine. Cluster creation can take a few minutes and we need to wait till it's finished in order to deploy Speedscale components to it. Once it's done, setup `kubectl` access by running
+We need to create a GKE cluster in order to run our proxy and forwarding components. Follow the prompts in the Google Cloud console to create a standard GKE cluster. Do not create an Autopilot cluster for this setup. If you specifically need Autopilot, follow the [GKE Autopilot guide](/getting-started/installation/install/gke-autopilot) instead. All other standard settings should be fine. Cluster creation can take a few minutes and we need to wait till it's finished in order to deploy Speedscale components to it. Once it's done, setup `kubectl` access by running
 
 ```
 gcloud container clusters get-credential <cluster-name> --region <region>

--- a/docs/getting-started/installation/install/ecs.md
+++ b/docs/getting-started/installation/install/ecs.md
@@ -15,7 +15,24 @@ This workflow is currently in preview status. Please provide feedback in our [sl
 
 ## Working with ECS
 
-![Architecture](./ecs/arch.png)
+```mermaid
+flowchart LR
+    client["Client / Internet"] --> loadBalancer["Load balancer"]
+
+    subgraph ecs["ECS task"]
+        certInit["Certificate init"]
+        proxy["goproxy<br/>inbound 4143 / outbound 4140"]
+        service["Application service"]
+        forwarder["Forwarder"]
+        certInit --> proxy
+        certInit --> service
+        proxy <--> service
+        proxy --> forwarder
+    end
+
+    loadBalancer --> proxy
+    forwarder --> cloud["Speedscale Cloud"]
+```
 
 To capture traffic for a service running in ECS, we need to setup some components shown above. The examples snippets in this guide will be in the form of Terraform but all the parameters used have equivalents in CloudFormation, the AWS CLI, the AWS console, etc.
 

--- a/docs/getting-started/installation/install/gke-autopilot.md
+++ b/docs/getting-started/installation/install/gke-autopilot.md
@@ -12,7 +12,7 @@ This workflow is currently in preview status. Please provide feedback in our [Sl
 
 [GKE Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) is Google's fully managed mode for GKE. Autopilot blocks privileged workloads by default through its Warden admission controller. The Speedscale eBPF capture agent (`nettap`) needs Linux capabilities, host namespace access, and a few `hostPath` mounts that Warden rejects unless the workload is explicitly allowed.
 
-## Capture options on Autopilot
+## Capture Options on Autopilot
 
 Autopilot's restrictions affect how Speedscale captures traffic. There are two supported approaches. Pick one:
 
@@ -56,7 +56,7 @@ gcloud services enable \
   --project "${PROJECT_ID}"
 ```
 
-## 1. Request WorkloadAllowlist eligibility
+## 1. Request WorkloadAllowlist Eligibility
 
 Create a Google Cloud support case.
 
@@ -85,7 +85,7 @@ Region: REGION
 
 Stop here until Google confirms the project is eligible for customer-owned WorkloadAllowlists. This usually takes 3 to 7 business days.
 
-## 2. Upload the Speedscale allowlist
+## 2. Upload the Speedscale Allowlist
 
 After Google approves the project, create a bucket and upload the allowlist:
 
@@ -115,7 +115,7 @@ gcloud storage buckets add-iam-policy-binding "gs://${BUCKET_NAME}" \
 
 The service account must use `container-engine-robot.iam.gserviceaccount.com`.
 
-## 3. Allow the bucket path
+## 3. Allow the Bucket Path
 
 Set the `container.managed.autopilotPrivilegedAdmission` org policy at the project level. Keep `allowAnyGKEPath: true` to preserve the default GKE-approved allowlists while adding the Speedscale bucket path.
 
@@ -137,7 +137,7 @@ gcloud org-policies set-policy /tmp/speedscale-autopilot-policy.yaml \
 
 Wait about 15 minutes before creating or updating the cluster.
 
-## 4. Create or update the Autopilot cluster
+## 4. Create or Update the Autopilot Cluster
 
 For a new cluster:
 
@@ -191,7 +191,7 @@ kubectl get workloadallowlist speedscale-nettap -o yaml
 
 If the synchronizer is not Ready, inspect `status.conditions[*].message` and `status.managedAllowlistStatus[*].lastError`.
 
-## 6. Install Speedscale with eBPF
+## 6. Install Speedscale With eBPF
 
 Add the Speedscale Helm repo and [install the operator](./kubernetes-operator.md) with eBPF enabled.
 
@@ -224,7 +224,7 @@ kubectl get pods -n speedscale -l app=speedscale-nettap
 
 The nettap pod should show `2/2 Running` on each node.
 
-## 7. Configure a capture target
+## 7. Configure a Capture Target
 
 Set the namespace and app label for the workload you want to capture, then add it as an eBPF capture target:
 
@@ -241,7 +241,7 @@ helm upgrade speedscale-operator speedscale/speedscale-operator \
 
 Generate traffic against the workload, then confirm it appears in Speedscale.
 
-## Updating Speedscale versions
+## Updating Speedscale Versions
 
 The Speedscale WorkloadAllowlist matches the approved workload shape and image repositories rather than a specific operator version. Upgrade the operator normally with Helm; the existing `workload-allowlist.yaml` and `AllowlistSynchronizer` continue to apply.
 
@@ -254,7 +254,7 @@ helm upgrade speedscale-operator speedscale/speedscale-operator \
 
 If Speedscale changes the privileged workload shape, Speedscale support will provide an updated allowlist. Upload it to the existing bucket path and the `AllowlistSynchronizer` will install it automatically.
 
-## Java Agent notes
+## Java Agent Notes
 
 For workloads that make outbound HTTPS calls, the Speedscale [Java Agent](../../../reference/languages/java.md) instruments `SSLSocketImpl` and `SSLEngineImpl` to decrypt TLS traffic.
 
@@ -271,7 +271,7 @@ On Autopilot, the operator's Java Agent init container can be rejected if the in
 | Replay init containers rejected by Warden | Missing `ephemeral-storage` values | Reinstall with the `sidecar.resources.*.ephemeral-storage=100Mi` values |
 | Forwarder crashes with `FATAL: failed to get filter rule` | `filterRule=none` in the configmap | Patch it: `kubectl patch cm speedscale-forwarder -n speedscale --type merge -p '{"data":{"SPEEDSCALE_FILTER_RULE":"standard"}}'` |
 
-## Sidecar capture (dual proxy mode)
+## Sidecar Capture (Dual Proxy Mode)
 
 :::warning Sidecar capture is deprecated
 Use the eBPF installation above for new GKE Autopilot deployments. Follow this section only for an existing sidecar deployment or when you cannot obtain the WorkloadAllowlist required by eBPF.
@@ -329,6 +329,6 @@ Dual mode does not reconfigure your runtime. The app must route outbound traffic
 
 See [TLS Support](/getting-started/installation/sidecar/tls.md) for outbound TLS decryption details.
 
-## Getting help
+## Getting Help
 
 If you are experiencing issues with this guide and have further questions, please reach out to us on the [community Slack](https://slack.speedscale.com).

--- a/docs/getting-started/installation/install/gke-autopilot.md
+++ b/docs/getting-started/installation/install/gke-autopilot.md
@@ -1,6 +1,6 @@
 ---
 title: GKE Autopilot
-description: The complete guide to running Speedscale on GKE Autopilot. Covers eBPF capture with a customer-owned WorkloadAllowlist and the deprecated sidecar fallback, plus the Helm values required to pass Warden admission.
+description: The complete guide to running Speedscale on GKE Autopilot. Covers both capture paths — eBPF via a customer-owned WorkloadAllowlist (support request, org policy, AllowlistSynchronizer) and sidecar dual proxy mode — plus the Autopilot-specific Helm values required to pass Warden admission.
 sidebar_position: 12
 ---
 
@@ -14,9 +14,9 @@ This workflow is currently in preview status. Please provide feedback in our [Sl
 
 ## Capture Options on Autopilot
 
-Autopilot's restrictions affect how Speedscale captures traffic. There are two supported approaches. Pick one:
+Autopilot's restrictions affect how Speedscale captures traffic. There are two supported approaches — pick one:
 
-- **eBPF capture** (the main path on this page). A privileged `nettap` DaemonSet captures traffic for whole namespaces. It needs a **customer-owned [WorkloadAllowlist](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-privileged-allowlists)** to admit the privileged pods, which requires a one-time Google Cloud eligibility request (about one week of lead time). The Speedscale allowlist is version-independent, so one file supports operator upgrades without a matching allowlist for every release.
+- **eBPF capture** (the main path on this page). A privileged `nettap` DaemonSet captures traffic for whole namespaces. It needs a **customer-owned [WorkloadAllowlist](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-privileged-allowlists)** to admit the privileged pods, which requires a one-time Google Cloud eligibility request (about one week of lead time). Best for broad, low-touch capture across many workloads. This path is needed until the Speedscale Autopilot partner allowlist is published globally.
 - **[Sidecar capture (dual proxy mode)](#sidecar-capture-dual-proxy-mode)** (deprecated). A per-workload sidecar proxy retained for existing deployments and clusters that cannot obtain a WorkloadAllowlist. Autopilot forbids the sidecar's transparent proxy, so it must run in `dual` proxy mode and the app's outbound traffic must be pointed at it.
 
 The rest of this page walks through the recommended eBPF path. Jump to [Sidecar Capture](#sidecar-capture-dual-proxy-mode) only if you need the deprecated fallback.
@@ -28,11 +28,11 @@ The rest of this page walks through the recommended eBPF path. Jump to [Sidecar 
 - Permission to set project org policies.
 - `gcloud`, `kubectl`, and `helm`.
 - A Speedscale API key.
-- Two version-independent files from Speedscale support:
+- Two files from Speedscale support, matched to a specific operator chart version:
   - `workload-allowlist.yaml`
   - `allowlist-synchronizer.yaml`
 
-Contact [Speedscale support](https://slack.speedscale.com) to get the allowlist files. Keep these files in version control with your cluster configuration. You do not need a new `workload-allowlist.yaml` when upgrading the operator.
+Contact [Speedscale support](https://slack.speedscale.com) to get the allowlist files. The `workload-allowlist.yaml` pins exact container image SHA-256 digests, so it is tied to one operator chart version. Install that exact chart version (see [Step 6](#6-install-speedscale-with-ebpf)).
 
 Set these variables for the commands below:
 
@@ -42,6 +42,7 @@ export REGION="us-central1"
 export CLUSTER_NAME="YOUR_CLUSTER_NAME"
 export BUCKET_NAME="${PROJECT_ID}-speedscale-autopilot-allowlists"
 export SPEEDSCALE_API_KEY="YOUR_SPEEDSCALE_API_KEY"
+export CHART_VERSION="VERSION_MATCHED_TO_YOUR_ALLOWLIST"
 ```
 
 Enable the required APIs:
@@ -195,11 +196,16 @@ If the synchronizer is not Ready, inspect `status.conditions[*].message` and `st
 
 Add the Speedscale Helm repo and [install the operator](./kubernetes-operator.md) with eBPF enabled.
 
+:::caution Pin the chart version
+Install the chart version that matches your `workload-allowlist.yaml`. The allowlist pins exact image SHA-256 digests; a different chart version pulls different `nettap`/`goproxy` images whose digests will not match, and Warden will reject the nettap pods. To move to a newer version, get a re-pinned `workload-allowlist.yaml` from Speedscale first.
+:::
+
 ```bash
 helm repo add speedscale https://speedscale.github.io/operator-helm/
 helm repo update
 
 helm upgrade --install speedscale-operator speedscale/speedscale-operator \
+  --version "${CHART_VERSION}" \
   --namespace speedscale --create-namespace \
   --set apiKey="${SPEEDSCALE_API_KEY}" \
   --set clusterName="${CLUSTER_NAME}" \
@@ -233,26 +239,32 @@ export APP_NAMESPACE="YOUR_APP_NAMESPACE"
 export APP_NAME="YOUR_APP_LABEL"
 
 helm upgrade speedscale-operator speedscale/speedscale-operator \
+  --version "${CHART_VERSION}" \
   --namespace speedscale --reuse-values \
   --set "ebpf.configuration.capture.targets[0].name=${APP_NAME}" \
   --set "ebpf.configuration.capture.targets[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name=${APP_NAMESPACE}" \
   --set "ebpf.configuration.capture.targets[0].podSelector.matchLabels.app=${APP_NAME}"
 ```
 
-Generate traffic against the workload, then confirm it appears in Speedscale.
+`--reuse-values` preserves your install values but not the chart version, so pin `--version` again here. Generate traffic against the workload, then confirm it appears in Speedscale.
 
 ## Updating Speedscale Versions
 
-The Speedscale WorkloadAllowlist matches the approved workload shape and image repositories rather than a specific operator version. Upgrade the operator normally with Helm; the existing `workload-allowlist.yaml` and `AllowlistSynchronizer` continue to apply.
+The WorkloadAllowlist pins container image digests, so it must be updated in lockstep with the chart. When Speedscale provides an updated `workload-allowlist.yaml` (and its matching chart version), upload it to the same bucket path:
 
 ```bash
-helm repo update
-helm upgrade speedscale-operator speedscale/speedscale-operator \
-  --namespace speedscale \
-  --reuse-values
+gcloud storage cp workload-allowlist.yaml \
+  "gs://${BUCKET_NAME}/nettap/workload-allowlist.yaml"
 ```
 
-If Speedscale changes the privileged workload shape, Speedscale support will provide an updated allowlist. Upload it to the existing bucket path and the `AllowlistSynchronizer` will install it automatically.
+Force a sync:
+
+```bash
+kubectl annotate allowlistsynchronizer speedscale-nettap-sync \
+  force-sync="$(date +%s)" --overwrite
+```
+
+Then upgrade the chart to the matching `--version`.
 
 ## Java Agent Notes
 
@@ -269,6 +281,7 @@ On Autopilot, the operator's Java Agent init container can be rejected if the in
 | AllowlistSynchronizer not Ready | Bucket IAM, path mismatch, invalid YAML, or incompatible GKE version | Confirm `container-engine-robot` has `objectViewer` and `bucketViewer`, then inspect synchronizer status |
 | Nettap pods rejected by Warden | Resource requests and limits do not match | Reinstall with matching requests and limits |
 | Replay init containers rejected by Warden | Missing `ephemeral-storage` values | Reinstall with the `sidecar.resources.*.ephemeral-storage=100Mi` values |
+| Nettap image digest mismatch after a chart upgrade | Installed chart version does not match the allowlist | Install the chart `--version` that matches your `workload-allowlist.yaml`, or upload the updated allowlist from Speedscale |
 | Forwarder crashes with `FATAL: failed to get filter rule` | `filterRule=none` in the configmap | Patch it: `kubectl patch cm speedscale-forwarder -n speedscale --type merge -p '{"data":{"SPEEDSCALE_FILTER_RULE":"standard"}}'` |
 
 ## Sidecar Capture (Dual Proxy Mode)
@@ -321,7 +334,7 @@ sidecar.speedscale.com/ephemeral-storage-limit: 100Mi
 
 ### Configure the application
 
-Dual mode does not reconfigure your runtime. The app must route outbound traffic to the sidecar's forward proxy on `127.0.0.1:4140` unless you changed `proxy-out-port`:
+Dual mode does not reconfigure your runtime — the app must route outbound traffic to the sidecar's forward proxy on `127.0.0.1:4140` (unless you changed `proxy-out-port`):
 
 - **Java:** add `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, and `-Dhttps.proxyPort` via `JAVA_TOOL_OPTIONS`. If you enable `tls-out`, add the truststore flags from the [Java reference](/reference/languages/java.md).
 - **Runtimes that honor proxy env vars:** set `HTTP_PROXY` and `HTTPS_PROXY` to `http://127.0.0.1:4140`.

--- a/docs/getting-started/installation/install/gke-autopilot.md
+++ b/docs/getting-started/installation/install/gke-autopilot.md
@@ -1,6 +1,6 @@
 ---
 title: GKE Autopilot
-description: The complete guide to running Speedscale on GKE Autopilot. Covers both capture paths — eBPF via a customer-owned WorkloadAllowlist (support request, org policy, AllowlistSynchronizer) and sidecar dual proxy mode — plus the Autopilot-specific Helm values required to pass Warden admission.
+description: The complete guide to running Speedscale on GKE Autopilot. Covers eBPF capture with a customer-owned WorkloadAllowlist and the deprecated sidecar fallback, plus the Helm values required to pass Warden admission.
 sidebar_position: 12
 ---
 
@@ -12,11 +12,11 @@ This workflow is currently in preview status. Please provide feedback in our [Sl
 
 [GKE Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) is Google's fully managed mode for GKE. Autopilot blocks privileged workloads by default through its Warden admission controller. The Speedscale eBPF capture agent (`nettap`) needs Linux capabilities, host namespace access, and a few `hostPath` mounts that Warden rejects unless the workload is explicitly allowed.
 
-## Capture Options on Autopilot
+## Capture options on Autopilot
 
-Autopilot's restrictions affect how Speedscale captures traffic. There are two supported approaches — pick one:
+Autopilot's restrictions affect how Speedscale captures traffic. There are two supported approaches. Pick one:
 
-- **eBPF capture** (the main path on this page). A privileged `nettap` DaemonSet captures traffic for whole namespaces. It needs a **customer-owned [WorkloadAllowlist](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-privileged-allowlists)** to admit the privileged pods, which requires a one-time Google Cloud eligibility request (about one week of lead time). Best for broad, low-touch capture across many workloads. This path is needed until the Speedscale Autopilot partner allowlist is published globally.
+- **eBPF capture** (the main path on this page). A privileged `nettap` DaemonSet captures traffic for whole namespaces. It needs a **customer-owned [WorkloadAllowlist](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-privileged-allowlists)** to admit the privileged pods, which requires a one-time Google Cloud eligibility request (about one week of lead time). The Speedscale allowlist is version-independent, so one file supports operator upgrades without a matching allowlist for every release.
 - **[Sidecar capture (dual proxy mode)](#sidecar-capture-dual-proxy-mode)** (deprecated). A per-workload sidecar proxy retained for existing deployments and clusters that cannot obtain a WorkloadAllowlist. Autopilot forbids the sidecar's transparent proxy, so it must run in `dual` proxy mode and the app's outbound traffic must be pointed at it.
 
 The rest of this page walks through the recommended eBPF path. Jump to [Sidecar Capture](#sidecar-capture-dual-proxy-mode) only if you need the deprecated fallback.
@@ -28,11 +28,11 @@ The rest of this page walks through the recommended eBPF path. Jump to [Sidecar 
 - Permission to set project org policies.
 - `gcloud`, `kubectl`, and `helm`.
 - A Speedscale API key.
-- Two files from Speedscale support, matched to a specific operator chart version:
+- Two version-independent files from Speedscale support:
   - `workload-allowlist.yaml`
   - `allowlist-synchronizer.yaml`
 
-Contact [Speedscale support](https://slack.speedscale.com) to get the allowlist files. The `workload-allowlist.yaml` pins exact container image SHA-256 digests, so it is tied to one operator chart version. Install that exact chart version (see [Step 6](#6-install-speedscale-with-ebpf)).
+Contact [Speedscale support](https://slack.speedscale.com) to get the allowlist files. Keep these files in version control with your cluster configuration. You do not need a new `workload-allowlist.yaml` when upgrading the operator.
 
 Set these variables for the commands below:
 
@@ -42,7 +42,6 @@ export REGION="us-central1"
 export CLUSTER_NAME="YOUR_CLUSTER_NAME"
 export BUCKET_NAME="${PROJECT_ID}-speedscale-autopilot-allowlists"
 export SPEEDSCALE_API_KEY="YOUR_SPEEDSCALE_API_KEY"
-export CHART_VERSION="VERSION_MATCHED_TO_YOUR_ALLOWLIST"
 ```
 
 Enable the required APIs:
@@ -57,7 +56,7 @@ gcloud services enable \
   --project "${PROJECT_ID}"
 ```
 
-## 1. Request WorkloadAllowlist Eligibility
+## 1. Request WorkloadAllowlist eligibility
 
 Create a Google Cloud support case.
 
@@ -86,7 +85,7 @@ Region: REGION
 
 Stop here until Google confirms the project is eligible for customer-owned WorkloadAllowlists. This usually takes 3 to 7 business days.
 
-## 2. Upload the Speedscale Allowlist
+## 2. Upload the Speedscale allowlist
 
 After Google approves the project, create a bucket and upload the allowlist:
 
@@ -116,7 +115,7 @@ gcloud storage buckets add-iam-policy-binding "gs://${BUCKET_NAME}" \
 
 The service account must use `container-engine-robot.iam.gserviceaccount.com`.
 
-## 3. Allow the Bucket Path
+## 3. Allow the bucket path
 
 Set the `container.managed.autopilotPrivilegedAdmission` org policy at the project level. Keep `allowAnyGKEPath: true` to preserve the default GKE-approved allowlists while adding the Speedscale bucket path.
 
@@ -138,7 +137,7 @@ gcloud org-policies set-policy /tmp/speedscale-autopilot-policy.yaml \
 
 Wait about 15 minutes before creating or updating the cluster.
 
-## 4. Create or Update the Autopilot Cluster
+## 4. Create or update the Autopilot cluster
 
 For a new cluster:
 
@@ -192,20 +191,15 @@ kubectl get workloadallowlist speedscale-nettap -o yaml
 
 If the synchronizer is not Ready, inspect `status.conditions[*].message` and `status.managedAllowlistStatus[*].lastError`.
 
-## 6. Install Speedscale With eBPF
+## 6. Install Speedscale with eBPF
 
 Add the Speedscale Helm repo and [install the operator](./kubernetes-operator.md) with eBPF enabled.
-
-:::caution Pin the chart version
-Install the chart version that matches your `workload-allowlist.yaml`. The allowlist pins exact image SHA-256 digests; a different chart version pulls different `nettap`/`goproxy` images whose digests will not match, and Warden will reject the nettap pods. To move to a newer version, get a re-pinned `workload-allowlist.yaml` from Speedscale first.
-:::
 
 ```bash
 helm repo add speedscale https://speedscale.github.io/operator-helm/
 helm repo update
 
 helm upgrade --install speedscale-operator speedscale/speedscale-operator \
-  --version "${CHART_VERSION}" \
   --namespace speedscale --create-namespace \
   --set apiKey="${SPEEDSCALE_API_KEY}" \
   --set clusterName="${CLUSTER_NAME}" \
@@ -230,7 +224,7 @@ kubectl get pods -n speedscale -l app=speedscale-nettap
 
 The nettap pod should show `2/2 Running` on each node.
 
-## 7. Configure a Capture Target
+## 7. Configure a capture target
 
 Set the namespace and app label for the workload you want to capture, then add it as an eBPF capture target:
 
@@ -239,34 +233,28 @@ export APP_NAMESPACE="YOUR_APP_NAMESPACE"
 export APP_NAME="YOUR_APP_LABEL"
 
 helm upgrade speedscale-operator speedscale/speedscale-operator \
-  --version "${CHART_VERSION}" \
   --namespace speedscale --reuse-values \
   --set "ebpf.configuration.capture.targets[0].name=${APP_NAME}" \
   --set "ebpf.configuration.capture.targets[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name=${APP_NAMESPACE}" \
   --set "ebpf.configuration.capture.targets[0].podSelector.matchLabels.app=${APP_NAME}"
 ```
 
-`--reuse-values` preserves your install values but not the chart version, so pin `--version` again here. Generate traffic against the workload, then confirm it appears in Speedscale.
+Generate traffic against the workload, then confirm it appears in Speedscale.
 
-## Updating Speedscale Versions
+## Updating Speedscale versions
 
-The WorkloadAllowlist pins container image digests, so it must be updated in lockstep with the chart. When Speedscale provides an updated `workload-allowlist.yaml` (and its matching chart version), upload it to the same bucket path:
-
-```bash
-gcloud storage cp workload-allowlist.yaml \
-  "gs://${BUCKET_NAME}/nettap/workload-allowlist.yaml"
-```
-
-Force a sync:
+The Speedscale WorkloadAllowlist matches the approved workload shape and image repositories rather than a specific operator version. Upgrade the operator normally with Helm; the existing `workload-allowlist.yaml` and `AllowlistSynchronizer` continue to apply.
 
 ```bash
-kubectl annotate allowlistsynchronizer speedscale-nettap-sync \
-  force-sync="$(date +%s)" --overwrite
+helm repo update
+helm upgrade speedscale-operator speedscale/speedscale-operator \
+  --namespace speedscale \
+  --reuse-values
 ```
 
-Then upgrade the chart to the matching `--version`.
+If Speedscale changes the privileged workload shape, Speedscale support will provide an updated allowlist. Upload it to the existing bucket path and the `AllowlistSynchronizer` will install it automatically.
 
-## Java Agent Notes
+## Java Agent notes
 
 For workloads that make outbound HTTPS calls, the Speedscale [Java Agent](../../../reference/languages/java.md) instruments `SSLSocketImpl` and `SSLEngineImpl` to decrypt TLS traffic.
 
@@ -281,10 +269,9 @@ On Autopilot, the operator's Java Agent init container can be rejected if the in
 | AllowlistSynchronizer not Ready | Bucket IAM, path mismatch, invalid YAML, or incompatible GKE version | Confirm `container-engine-robot` has `objectViewer` and `bucketViewer`, then inspect synchronizer status |
 | Nettap pods rejected by Warden | Resource requests and limits do not match | Reinstall with matching requests and limits |
 | Replay init containers rejected by Warden | Missing `ephemeral-storage` values | Reinstall with the `sidecar.resources.*.ephemeral-storage=100Mi` values |
-| Nettap image digest mismatch after a chart upgrade | Installed chart version does not match the allowlist | Install the chart `--version` that matches your `workload-allowlist.yaml`, or upload the updated allowlist from Speedscale |
 | Forwarder crashes with `FATAL: failed to get filter rule` | `filterRule=none` in the configmap | Patch it: `kubectl patch cm speedscale-forwarder -n speedscale --type merge -p '{"data":{"SPEEDSCALE_FILTER_RULE":"standard"}}'` |
 
-## Sidecar Capture (Dual Proxy Mode)
+## Sidecar capture (dual proxy mode)
 
 :::warning Sidecar capture is deprecated
 Use the eBPF installation above for new GKE Autopilot deployments. Follow this section only for an existing sidecar deployment or when you cannot obtain the WorkloadAllowlist required by eBPF.
@@ -334,7 +321,7 @@ sidecar.speedscale.com/ephemeral-storage-limit: 100Mi
 
 ### Configure the application
 
-Dual mode does not reconfigure your runtime — the app must route outbound traffic to the sidecar's forward proxy on `127.0.0.1:4140` (unless you changed `proxy-out-port`):
+Dual mode does not reconfigure your runtime. The app must route outbound traffic to the sidecar's forward proxy on `127.0.0.1:4140` unless you changed `proxy-out-port`:
 
 - **Java:** add `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, and `-Dhttps.proxyPort` via `JAVA_TOOL_OPTIONS`. If you enable `tls-out`, add the truststore flags from the [Java reference](/reference/languages/java.md).
 - **Runtimes that honor proxy env vars:** set `HTTP_PROXY` and `HTTPS_PROXY` to `http://127.0.0.1:4140`.
@@ -342,6 +329,6 @@ Dual mode does not reconfigure your runtime — the app must route outbound traf
 
 See [TLS Support](/getting-started/installation/sidecar/tls.md) for outbound TLS decryption details.
 
-## Getting Help
+## Getting help
 
 If you are experiencing issues with this guide and have further questions, please reach out to us on the [community Slack](https://slack.speedscale.com).

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -31,7 +31,7 @@ Choose the operating model that matches your security requirements:
 
 ### AI Assistant
 
-The fastest way to get started is the **AI assistant** on the home screen. Ask it questions in natural language — it can help you record traffic, find snapshots, run replays, and interpret results. See the [AI Chat Assistant guide](/guides/ai-assistant) for details on what it can do.
+The fastest way to get started is the **AI assistant** on the home screen. Ask it questions in natural language. It can help you record traffic, find snapshots, run replays, and interpret results. See the [AI Chat Assistant guide](/guides/ai-assistant) for details on what it can do.
 
 Speedscale follows a 3-part workflow: **Observe**, **Analyze**, and **Replay**.
 
@@ -39,9 +39,34 @@ Speedscale follows a 3-part workflow: **Observe**, **Analyze**, and **Replay**.
 
 In **Observe**, use eBPF collection first in late-stage containerized environments (for example UAT, staging, or production). If eBPF is not suitable, use goproxy sidecars. For local workflows outside Kubernetes, use proxymock for the same record/mock/replay pattern.
 
-![](../speedscale-data-capture.png)
+```mermaid
+flowchart LR
+    subgraph sources["Traffic sources"]
+        users["Users and clients"]
+        services["Internal APIs"]
+    end
 
-The proxy captures two data flows: inbound traffic to your API and outbound traffic to dependencies, including responses. This allows Speedscale to transform inbound requests into replayable tests and dependency traffic into mocked services for isolated replay.
+    subgraph cluster["Kubernetes cluster"]
+        app["Application workload"]
+        nettap["nettap eBPF collector"]
+        forwarder["Forwarder<br/>filtering and DLP"]
+    end
+
+    subgraph dependencies["Dependencies"]
+        saas["External APIs"]
+        data["Databases and services"]
+    end
+
+    users --> app
+    services --> app
+    app --> saas
+    app --> data
+    nettap -. "observes inbound and outbound traffic" .-> app
+    nettap --> forwarder
+    forwarder --> cloud["Speedscale Cloud"]
+```
+
+The collector captures two data flows: inbound traffic to your API and outbound traffic to dependencies, including responses. This allows Speedscale to transform inbound requests into replayable tests and dependency traffic into mocked services for isolated replay.
 
 Captured traffic is sent to Speedscale for storage and analysis.
 

--- a/docs/guides/a2a-load-testing.md
+++ b/docs/guides/a2a-load-testing.md
@@ -5,11 +5,11 @@ sidebar_position: 0
 
 # Load Testing Agent-to-Agent (A2A) API Calls
 
-## What is the A2A protocol?
+## What is the A2A Protocol?
 
 The [Agent-to-Agent (A2A) protocol](https://github.com/a2aproject/A2A) is an open protocol that enables communication and interoperability between opaque agentic applications. As AI systems become more specialized and distributed, A2A provides a standardized way for diverse AI agents built on different frameworks and hosted on separate servers to discover, negotiate with, and collaborate on tasks.
 
-### Key features of A2A
+### Key Features of A2A
 
 The A2A protocol solves the challenge of agent silos by enabling:
 
@@ -18,7 +18,7 @@ The A2A protocol solves the challenge of agent silos by enabling:
 - **Collaboration**: Multiple agents can work together securely on extended tasks
 - **Opacity**: Agents collaborate without revealing internal state, memory, or proprietary tools
 
-### Technical foundation
+### Technical Foundation
 
 The A2A protocol is built on standard web technologies:
 
@@ -31,11 +31,11 @@ The A2A protocol is built on standard web technologies:
 
 The A2A Protocol is a Linux Foundation open-source project with contributions from Google, licensed under Apache 2.0.
 
-## Load testing A2A with Speedscale
+## Load Testing A2A with Speedscale
 
 Since A2A uses JSON-RPC 2.0 over HTTP(S), it can be load tested like any other HTTP-based API using Speedscale's traffic replay capabilities. The standard HTTP foundation means existing load testing infrastructure and techniques apply directly to A2A implementations.
 
-### How traffic replay works for A2A
+### How Traffic Replay Works for A2A
 
 Speedscale captures real A2A traffic between agents and replays it at scale:
 
@@ -44,7 +44,7 @@ Speedscale captures real A2A traffic between agents and replays it at scale:
 3. **Replay**: Configure a [test config](/reference/glossary.md#test-config) with your desired load pattern (see [Load Testing guide](/guides/replay/load-test.md))
 4. **Analyze**: Review response accuracy, latency, and throughput to identify bottlenecks
 
-### Configuring load patterns for A2A
+### Configuring Load Patterns for A2A
 
 A2A workloads often involve complex multi-agent interactions. Consider these approaches:
 
@@ -54,9 +54,9 @@ A2A workloads often involve complex multi-agent interactions. Consider these app
 
 See the [Load Testing guide](/guides/replay/load-test.md) for detailed configuration instructions.
 
-## Common performance and testing issues with A2A
+## Common Performance and Testing Issues with A2A
 
-### 1. Long-running agent conversations
+### 1. Long-Running Agent Conversations
 
 A2A enables extended multi-turn conversations between agents. These long-lived sessions can:
 
@@ -66,7 +66,7 @@ A2A enables extended multi-turn conversations between agents. These long-lived s
 
 **Testing Strategy**: Use soak tests with realistic conversation lengths to identify memory leaks and connection exhaustion. Monitor agent response times throughout the test duration.
 
-### 2. Server-Sent Events (SSE) streaming
+### 2. Server-Sent Events (SSE) Streaming
 
 A2A's streaming support via SSE introduces specific challenges:
 
@@ -76,7 +76,7 @@ A2A's streaming support via SSE introduces specific challenges:
 
 **Testing Strategy**: Capture and replay SSE streams to validate connection stability. Test with various load balancer timeout configurations to ensure streaming reliability at scale.
 
-### 3. Agent discovery and negotiation overhead
+### 3. Agent Discovery and Negotiation Overhead
 
 The A2A discovery phase involves:
 
@@ -86,7 +86,7 @@ The A2A discovery phase involves:
 
 **Testing Strategy**: Measure the time agents spend in discovery vs. actual work. Consider caching Agent Cards when appropriate to reduce discovery overhead.
 
-### 4. JSON-RPC error handling
+### 4. JSON-RPC Error Handling
 
 JSON-RPC 2.0 defines specific error codes and structures. Common issues include:
 
@@ -96,7 +96,7 @@ JSON-RPC 2.0 defines specific error codes and structures. Common issues include:
 
 **Testing Strategy**: Use [assertions](/reference/configuration/assertions/) to validate JSON-RPC error responses. Test failure scenarios where downstream agents return errors or time out.
 
-### 5. Dynamic agent networks
+### 5. Dynamic Agent Networks
 
 In production A2A deployments, agent availability changes dynamically:
 
@@ -106,7 +106,7 @@ In production A2A deployments, agent availability changes dynamically:
 
 **Testing Strategy**: Capture traffic from various network states. Test with different agent configurations to ensure your system handles topology changes gracefully.
 
-### 6. Authentication and security
+### 6. Authentication and Security
 
 A2A communications often involve:
 
@@ -116,14 +116,14 @@ A2A communications often involve:
 
 **Testing Strategy**: Use Speedscale's [transform capabilities](/guides/transformation/extractors/) to handle authentication tokens during replay. Test rate limiting behavior under high load to ensure legitimate agent traffic isn't blocked.
 
-## Best practices
+## Best Practices
 
 1. **Capture Representative Traffic**: Ensure your captured snapshots include the full range of A2A interactions: discovery, negotiation, synchronous calls, and streaming
 2. **Test Agent Independence**: Load test individual agents as well as the full agent network to identify single points of failure
 3. **Monitor End-to-End Latency**: Track total conversation time across multiple agent hops, not just individual request latency
 4. **Validate Agent Card Changes**: Test backward compatibility when updating agent capabilities to ensure existing agent relationships continue working
 
-## Learn more
+## Learn More
 
 - [Load Testing Guide](/guides/replay/load-test.md) - Configure and run load tests
 - [Traffic Replay Concepts](/concepts/replay.md) - Understand how replay works

--- a/docs/guides/a2a-load-testing.md
+++ b/docs/guides/a2a-load-testing.md
@@ -5,11 +5,11 @@ sidebar_position: 0
 
 # Load Testing Agent-to-Agent (A2A) API Calls
 
-## What is the A2A Protocol?
+## What is the A2A protocol?
 
 The [Agent-to-Agent (A2A) protocol](https://github.com/a2aproject/A2A) is an open protocol that enables communication and interoperability between opaque agentic applications. As AI systems become more specialized and distributed, A2A provides a standardized way for diverse AI agents built on different frameworks and hosted on separate servers to discover, negotiate with, and collaborate on tasks.
 
-### Key Features of A2A
+### Key features of A2A
 
 The A2A protocol solves the challenge of agent silos by enabling:
 
@@ -18,7 +18,7 @@ The A2A protocol solves the challenge of agent silos by enabling:
 - **Collaboration**: Multiple agents can work together securely on extended tasks
 - **Opacity**: Agents collaborate without revealing internal state, memory, or proprietary tools
 
-### Technical Foundation
+### Technical foundation
 
 The A2A protocol is built on standard web technologies:
 
@@ -31,20 +31,20 @@ The A2A protocol is built on standard web technologies:
 
 The A2A Protocol is a Linux Foundation open-source project with contributions from Google, licensed under Apache 2.0.
 
-## Load Testing A2A with Speedscale
+## Load testing A2A with Speedscale
 
 Since A2A uses JSON-RPC 2.0 over HTTP(S), it can be load tested like any other HTTP-based API using Speedscale's traffic replay capabilities. The standard HTTP foundation means existing load testing infrastructure and techniques apply directly to A2A implementations.
 
-### How Traffic Replay Works for A2A
+### How traffic replay works for A2A
 
 Speedscale captures real A2A traffic between agents and replays it at scale:
 
-1. **Capture**: Deploy the Speedscale sidecar to capture live A2A traffic between your agents, including JSON-RPC calls, SSE streams, and async notifications
+1. **Capture**: Enable the [eBPF collector](/reference/ebpf-traffic-collection) for the agent workloads to record live A2A traffic, including JSON-RPC calls, SSE streams, and async notifications
 2. **Transform**: Use [extractors and transformers](/guides/transformation/extractors/) to handle dynamic values in Agent Cards, session tokens, or agent-specific identifiers
 3. **Replay**: Configure a [test config](/reference/glossary.md#test-config) with your desired load pattern (see [Load Testing guide](/guides/replay/load-test.md))
 4. **Analyze**: Review response accuracy, latency, and throughput to identify bottlenecks
 
-### Configuring Load Patterns for A2A
+### Configuring load patterns for A2A
 
 A2A workloads often involve complex multi-agent interactions. Consider these approaches:
 
@@ -54,9 +54,9 @@ A2A workloads often involve complex multi-agent interactions. Consider these app
 
 See the [Load Testing guide](/guides/replay/load-test.md) for detailed configuration instructions.
 
-## Common Performance and Testing Issues with A2A
+## Common performance and testing issues with A2A
 
-### 1. Long-Running Agent Conversations
+### 1. Long-running agent conversations
 
 A2A enables extended multi-turn conversations between agents. These long-lived sessions can:
 
@@ -66,7 +66,7 @@ A2A enables extended multi-turn conversations between agents. These long-lived s
 
 **Testing Strategy**: Use soak tests with realistic conversation lengths to identify memory leaks and connection exhaustion. Monitor agent response times throughout the test duration.
 
-### 2. Server-Sent Events (SSE) Streaming
+### 2. Server-Sent Events (SSE) streaming
 
 A2A's streaming support via SSE introduces specific challenges:
 
@@ -76,7 +76,7 @@ A2A's streaming support via SSE introduces specific challenges:
 
 **Testing Strategy**: Capture and replay SSE streams to validate connection stability. Test with various load balancer timeout configurations to ensure streaming reliability at scale.
 
-### 3. Agent Discovery and Negotiation Overhead
+### 3. Agent discovery and negotiation overhead
 
 The A2A discovery phase involves:
 
@@ -86,7 +86,7 @@ The A2A discovery phase involves:
 
 **Testing Strategy**: Measure the time agents spend in discovery vs. actual work. Consider caching Agent Cards when appropriate to reduce discovery overhead.
 
-### 4. JSON-RPC Error Handling
+### 4. JSON-RPC error handling
 
 JSON-RPC 2.0 defines specific error codes and structures. Common issues include:
 
@@ -96,7 +96,7 @@ JSON-RPC 2.0 defines specific error codes and structures. Common issues include:
 
 **Testing Strategy**: Use [assertions](/reference/configuration/assertions/) to validate JSON-RPC error responses. Test failure scenarios where downstream agents return errors or time out.
 
-### 5. Dynamic Agent Networks
+### 5. Dynamic agent networks
 
 In production A2A deployments, agent availability changes dynamically:
 
@@ -106,7 +106,7 @@ In production A2A deployments, agent availability changes dynamically:
 
 **Testing Strategy**: Capture traffic from various network states. Test with different agent configurations to ensure your system handles topology changes gracefully.
 
-### 6. Authentication and Security
+### 6. Authentication and security
 
 A2A communications often involve:
 
@@ -116,14 +116,14 @@ A2A communications often involve:
 
 **Testing Strategy**: Use Speedscale's [transform capabilities](/guides/transformation/extractors/) to handle authentication tokens during replay. Test rate limiting behavior under high load to ensure legitimate agent traffic isn't blocked.
 
-## Best Practices
+## Best practices
 
 1. **Capture Representative Traffic**: Ensure your captured snapshots include the full range of A2A interactions: discovery, negotiation, synchronous calls, and streaming
 2. **Test Agent Independence**: Load test individual agents as well as the full agent network to identify single points of failure
 3. **Monitor End-to-End Latency**: Track total conversation time across multiple agent hops, not just individual request latency
 4. **Validate Agent Card Changes**: Test backward compatibility when updating agent capabilities to ensure existing agent relationships continue working
 
-## Learn More
+## Learn more
 
 - [Load Testing Guide](/guides/replay/load-test.md) - Configure and run load tests
 - [Traffic Replay Concepts](/concepts/replay.md) - Understand how replay works

--- a/docs/guides/argo.md
+++ b/docs/guides/argo.md
@@ -1,6 +1,6 @@
 ---
 title: Speedscale with Argo Rollouts
-description: "Capture traffic from Argo Rollouts with the Speedscale eBPF collector without modifying rollout pods."
+description: "Capture traffic from Argo Rollouts with the Speedscale eBPF collector and account for Java agent rollout changes."
 sidebar_position: 30
 ---
 
@@ -25,7 +25,9 @@ This restart is necessary because the inspector only creates watchers for Argo R
 
 ## Capture rollout traffic with eBPF
 
-The eBPF collector observes traffic from the node and does not inject a container into rollout pods. Enabling capture therefore does not create a new ReplicaSet, pause a rollout, or require promotion.
+The eBPF collector observes traffic from the node and does not inject a container into rollout pods. Enabling capture for a non-Java workload therefore does not create a new ReplicaSet, pause a rollout, or require promotion.
+
+Java TLS capture is an exception. The required `capture.speedscale.com/java-agent: "true"` annotation changes the pod template so the Operator can load the JVMTI agent. Treat that annotation change like any other Argo Rollouts pod template change and promote the resulting ReplicaSet.
 
 Enable eBPF in the Operator Helm values and target the stable label shared by the rollout pods:
 

--- a/docs/guides/argo.md
+++ b/docs/guides/argo.md
@@ -1,11 +1,8 @@
 ---
 title: Speedscale with Argo Rollouts
-description: "Integrate Speedscale with Argo Rollouts to enhance Kubernetes deployment control, ensuring proper setup and sidecar management for effective traffic replay."
+description: "Capture traffic from Argo Rollouts with the Speedscale eBPF collector without modifying rollout pods."
 sidebar_position: 30
 ---
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 [Argo Rollouts](https://argoproj.github.io/argo-rollouts/) are a popular way to
 gain more control over application deployment in Kubernetes but their design
@@ -26,108 +23,47 @@ kubectl rollout restart deployment/speedscale-inspector -n speedscale
 This restart is necessary because the inspector only creates watchers for Argo Rollouts if they're detected at startup.
 :::
 
-One of the primary selling points of a rollout is the ability to perform a
-partial deployment, promote it forward, or roll it back if it doesn't work. We
-respect your choice to maintain this control and for that reason all rollout
-modifications through Speedscale will require an extra step on your part to
-fully promote the change.
+## Capture rollout traffic with eBPF
 
-<Tabs>
+The eBPF collector observes traffic from the node and does not inject a container into rollout pods. Enabling capture therefore does not create a new ReplicaSet, pause a rollout, or require promotion.
 
-<TabItem value="webapp" label="Web App">
+Enable eBPF in the Operator Helm values and target the stable label shared by the rollout pods:
 
-From the [Speedscale web app](https://app.speedscale.com/) click on `Add
-service` and select your cluster configuration.
+```yaml title="ebpf-values.yaml"
+ebpf:
+  enabled: true
+  configuration:
+    capture:
+      targets:
+        - name: rollouts-demo
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: my-namespace
+          podSelector:
+            matchLabels:
+              app: rollouts-demo
+```
 
-![add-argo-rollout](./argo/add-service-argo-rollout.png)
-
-Once the sidecar has been added to the rollout the sidecar will be added to
-some pods. The status on the wizard will spin until the rollout has been
-promoted.
-
-![service-status](./argo/verify-argo-service.png)
-
-Verify changes and promote the rollout to apply to the rest of the pods:
+Apply the values:
 
 ```bash
-kubectl argo rollouts get rollout <rollout-name>
-kubectl argo rollouts promote <rollout-name>
+helm upgrade speedscale-operator speedscale/speedscale-operator \
+  --namespace speedscale \
+  --reuse-values \
+  -f ebpf-values.yaml
 ```
 
-The status on the wizard should complete and send a test request.
+Use an application label that remains stable across canary and stable ReplicaSets. Do not target `rollouts-pod-template-hash`, because that value changes with each rollout revision.
 
-</TabItem>
-
-<TabItem value="speedctl" label="speedctl CLI">
-
-Make sure you have [speedctl installed](/getting-started/installation/install/cli.md) before you
-start.  Verify you have the [inspector](/reference/glossary.md#inspector)
-running in your cluster with:
+Verify that nettap is running and both rollout revisions match the target:
 
 ```bash
-speedctl infra inspectors -o pretty
+kubectl -n speedscale get daemonset nettap
+kubectl -n my-namespace get pods -l app=rollouts-demo
 ```
 
-Using the proper cluster name, add the sidecar to the rollout:
+See [eBPF Traffic Collection](/reference/ebpf-traffic-collection) for TLS support, system requirements, and additional target options.
 
-```bash
-speedctl infra sidecar add <rollout-name> --cluster <cluster-name> -n <namespace> --workload-type argorollout
-```
-
-This will apply the sidecar to some pods. Verify changes and promote the
-rollout to apply to the rest of the pods:
-
-```bash
-kubectl argo rollouts get rollout <rollout-name>
-kubectl argo rollouts promote <rollout-name>
-```
-
-</TabItem>
-
-<TabItem value="annotation" label="Kubernetes Annotation">
-
-With cluster access you can add the sidecar with an annotation on your
-workload.
-
-Add the following annotation to the rollout:
-
-```yaml
-annotations:
-  sidecar.speedscale.com/inject: "true"
-```
-
-Unlike a deployment we need to patch the rollout to trigger the change:
-
-```bash
-now=$(date) && kubectl patch rollout rollouts-demo -p '{"spec": {"template": {"metadata": {"annotations": {"speedscale.com/restartedAt": "'$now'"}}}}}' --type merge
-```
-
-This will apply the sidecar to some pods. Verify changes and promote the
-rollout to apply to the rest of the pods:
-
-```bash
-kubectl argo rollouts get rollout <rollout-name>
-kubectl argo rollouts promote <rollout-name>
-```
-
-</TabItem>
-
-</Tabs>
-
-
-## Uninstall
-
-To uninstall the sidecar on an argo rollout, do the following.
-
-Modify the following annotation to the rollout, setting it to `false`:
-
-```yaml
-annotations:
-  sidecar.speedscale.com/inject: "false"
-```
-
-Depending on how your rollout is configured, it may not immediately change. In order to force it to change, you can add an annotation like this and your should see the rollout cycle and your sidecar is removed.
-
-```
-now=$(date) && kubectl patch rollout rollouts-demo -p '{"spec": {"template": {"metadata": {"annotations": {"speedscale.com/restartedAt": "'$now'"}}}}}' --type merge
-```
+:::warning Legacy sidecar deployments
+Existing deployments that intentionally use sidecar capture can continue to use `speedctl infra sidecar` and `sidecar.speedscale.com/inject`. Sidecar injection changes the rollout pod template and must be promoted through Argo Rollouts. New deployments should use eBPF capture.
+:::

--- a/docs/guides/argo.md
+++ b/docs/guides/argo.md
@@ -67,3 +67,20 @@ See [eBPF Traffic Collection](/reference/ebpf-traffic-collection) for TLS suppor
 :::warning Legacy sidecar deployments
 Existing deployments that intentionally use sidecar capture can continue to use `speedctl infra sidecar` and `sidecar.speedscale.com/inject`. Sidecar injection changes the rollout pod template and must be promoted through Argo Rollouts. New deployments should use eBPF capture.
 :::
+
+## Remove a sidecar from a rollout
+
+To remove a sidecar from an existing rollout, set the inject annotation to `false`:
+
+```yaml
+annotations:
+  sidecar.speedscale.com/inject: "false"
+```
+
+Depending on how the rollout is configured it may not cycle right away. Patch the pod template to force it:
+
+```bash
+now=$(date) && kubectl patch rollout rollouts-demo -p '{"spec": {"template": {"metadata": {"annotations": {"speedscale.com/restartedAt": "'$now'"}}}}}' --type merge
+```
+
+The rollout cycles and the sidecar is removed. This does not affect eBPF capture, which is controlled separately by the capture targets.

--- a/docs/guides/capture/infra.md
+++ b/docs/guides/capture/infra.md
@@ -39,7 +39,7 @@ To configure eBPF traffic capture or import a collection, follow the [tutorial](
 
 The Cluster Inspector presents cluster information in a tabular interface similar to K9s or kubectl. Use it to inspect the Speedscale deployment and the workloads it can access.
 
-### Key capabilities
+### Key Capabilities
 
 - **Workload Management**: View cluster workloads and their Speedscale capture status
 - **Traffic Monitoring**: Observe active traffic replays and analyze real-time traffic patterns
@@ -48,7 +48,7 @@ The Cluster Inspector presents cluster information in a tabular interface simila
 - **Service Discovery**: Explore services, secrets, and node information
 - **Remote Debugging**: Enhanced cluster debuggability for distributed teams
 
-## Primary features
+## Primary Features
 
 ### 1. Capture targeting and management
 
@@ -79,9 +79,9 @@ The Inspector also exposes workload logs and Kubernetes events for remote debugg
 - Enables non-Kubernetes experts to troubleshoot effectively
 - Provides context-rich debugging without cluster access credentials
 
-## Security and privacy
+## Security and Privacy
 
-### Data protection guarantees
+### Data Protection Guarantees
 
 **No secret extraction**: The Cluster Inspector never extracts or exposes Kubernetes secrets from your cluster. All sensitive data remains secure within your environment.
 
@@ -89,11 +89,11 @@ The Inspector also exposes workload logs and Kubernetes events for remote debugg
 
 **Audit trail**: All actions performed through the inspector are logged for security and compliance purposes.
 
-### Optional installation
+### Optional Installation
 
 The Cluster Inspector capability can be **completely disabled** by not installing the inspector service component. This provides organizations with full control over cluster access and debugging capabilities.
 
-## Remote replay and data collection
+## Remote Replay and Data Collection
 
 Speedscale provides the ability to remotely inspect and control Kubernetes clusters similar to [k9s](https://k9scli.io/) or [lens](https://k8slens.dev/). Unlike these inspection tools, Speedscale also allows clusters to be used for *remote replay*. Clusters assigned to Speedscale in this way can run replays on demand and can be treated as a shared resource for engineers or testers.
 
@@ -176,7 +176,7 @@ Use this tab to view currently running replays. Speedscale utilizes a Custom Res
 - Performance metrics and results analysis
 - Error rates and failure detection
 
-## Getting started with Cluster Inspector
+## Getting Started with Cluster Inspector
 
 ### Prerequisites
 
@@ -188,7 +188,7 @@ Use this tab to view currently running replays. Speedscale utilizes a Custom Res
 
 The Cluster Inspector is accessible through the Speedscale web interface under the **Observe** section. Navigate to your cluster view and select the cluster name to begin exploring your Kubernetes environment through the tabular interface.
 
-### Initial setup
+### Initial Setup
 
 1. **Verify permissions**: Ensure your user account has appropriate cluster access
 2. **Review workloads**: Start by exploring existing workloads and their current state
@@ -197,7 +197,7 @@ The Cluster Inspector is accessible through the Speedscale web interface under t
 
 ## Troubleshooting
 
-### Common issues
+### Common Issues
 
 **Inspector not accessible**: Verify the inspector service is installed and running in the cluster.
 
@@ -207,13 +207,13 @@ The Cluster Inspector is accessible through the Speedscale web interface under t
 
 **Log viewing problems**: Ensure proper logging drivers and log retention policies.
 
-### Debugging workflows
+### Debugging Workflows
 - Use the unified log view to correlate application, Operator, and collector behavior
 - Filter events by workload or namespace to focus troubleshooting
 - Leverage historical data for pattern analysis
 - Export logs for offline analysis when needed
 
-### Getting help
+### Getting Help
 
 For technical support with the Cluster Inspector:
 - Check the Speedscale operator logs for error messages

--- a/docs/guides/capture/infra.md
+++ b/docs/guides/capture/infra.md
@@ -1,65 +1,87 @@
 ---
-description: "Explore the Cluster Inspector in Speedscale to manage Kubernetes clusters, monitor traffic, and deploy sidecars for enhanced debugging and observability."
+description: "Use the Cluster Inspector to review Kubernetes workloads, traffic capture, configuration, logs, events, and active replays."
 sidebar_position: 3
 ---
 
 # Cluster Inspector
 
-![architecture](./infra/architecture.png)
+```mermaid
+flowchart TB
+    subgraph recording["Recording"]
+        k8sApp["Kubernetes workload"]
+        nettap["eBPF collector"]
+        localApp["Local process"]
+        localCapture["proxymock or speedctl capture"]
+        k8sApp -. "observed by" .-> nettap
+        localApp --> localCapture
+    end
+
+    cloud["Speedscale Cloud"]
+    nettap --> cloud
+    localCapture --> cloud
+
+    subgraph playback["Replay"]
+        localReplay["Local replay<br/>proxymock or speedctl"]
+        clusterReplay["Kubernetes replay<br/>generator and responder"]
+    end
+
+    cloud --> localReplay
+    cloud --> clusterReplay
+```
 
 Speedscale is a cloud SaaS offering that provides both observability and replay of remote environments. The system is designed to record traffic from a remote environment, the local desktop or through data import. Replay works in a similar way on a similar set of platforms. When working remotely, Speedscale provides a point and click interface for starting and stopping replays.
 
-The **Cluster Inspector** provides a comprehensive web-based interface for interrogating and managing Kubernetes clusters running Speedscale. This powerful debugging and management tool offers deep visibility into cluster workloads, configuration, and traffic patterns while maintaining strict security controls.
+The **Cluster Inspector** is a web interface for inspecting and managing Kubernetes clusters running Speedscale. It shows workloads, configuration, traffic, logs, and events while keeping operations within the configured Kubernetes RBAC boundaries.
 
-To learn how to configure a sidecar or import a collection in our [tutorial](../../getting-started/tutorial.md)
+To configure eBPF traffic capture or import a collection, follow the [tutorial](../../getting-started/tutorial.md).
 
 ## Overview
 
-The Cluster Inspector presents cluster information through an intuitive tabular interface similar to other Kubernetes management tools like K9s or kubectl. It serves as a central hub for observing and managing your Speedscale deployment across the entire cluster.
+The Cluster Inspector presents cluster information in a tabular interface similar to K9s or kubectl. Use it to inspect the Speedscale deployment and the workloads it can access.
 
-### Key Capabilities
+### Key capabilities
 
-- **Workload Management**: View and manage all cluster workloads with the ability to add Speedscale sidecars
+- **Workload Management**: View cluster workloads and their Speedscale capture status
 - **Traffic Monitoring**: Observe active traffic replays and analyze real-time traffic patterns
 - **Configuration Management**: Inspect and validate Speedscale configuration across the cluster
-- **Event & Log Analysis**: Access logs and events for both sidecars and workloads
+- **Event & Log Analysis**: Access workload, Operator, and collector logs and events
 - **Service Discovery**: Explore services, secrets, and node information
 - **Remote Debugging**: Enhanced cluster debuggability for distributed teams
 
-## Primary Features
+## Primary features
 
-### 1. Sidecar Injection and Management
+### 1. Capture targeting and management
 
-The most important capability of the Cluster Inspector is adding Speedscale sidecars to existing workloads. This feature enables:
+The Cluster Inspector shows which workloads are targeted for Speedscale capture. For new installations, enable the [eBPF collector](/reference/ebpf-traffic-collection) and use namespace and pod selectors or the `capture.speedscale.com/enabled` annotation to control the target set. This provides:
 
-- **One-click sidecar injection** for any workload in the cluster
-- **Selective deployment** - choose which workloads need traffic capture
-- **Configuration validation** before sidecar deployment
-- **Rollback capabilities** to remove sidecars when no longer needed
+- **Selective capture** for specific workloads and namespaces
+- **Capture status** without modifying application pods
+- **Configuration visibility** for the Operator and collector
+- **Fast rollback** by disabling a target annotation or selector
 
-**Use Cases:**
+**Use cases:**
 - Enable traffic capture on production workloads for testing
 - Add monitoring to specific microservices
-- Gradually roll out Speedscale across your application stack
+- Gradually roll out capture across your application stack
 
-### 2. Enhanced Debugging and Observability
+### 2. Debugging and observability
 
-The second most critical feature is comprehensive log and event interrogation, making clusters significantly more debuggable for remote users:
+The Inspector also exposes workload logs and Kubernetes events for remote debugging:
 
-- **Unified log viewing** for both application workloads and Speedscale sidecars
+- **Unified log viewing** for application workloads and Speedscale components
 - **Real-time event monitoring** with filtering and search capabilities
-- **Cross-reference logging** to correlate sidecar and application behavior
+- **Cross-reference logging** to correlate collector and application behavior
 - **Historical event analysis** for troubleshooting past issues
 
-**Benefits for Remote Teams:**
+**Benefits for remote teams:**
 - Eliminates need for direct kubectl access
 - Centralizes debugging information in a user-friendly interface
 - Enables non-Kubernetes experts to troubleshoot effectively
 - Provides context-rich debugging without cluster access credentials
 
-## Security and Privacy
+## Security and privacy
 
-### Data Protection Guarantees
+### Data protection guarantees
 
 **No secret extraction**: The Cluster Inspector never extracts or exposes Kubernetes secrets from your cluster. All sensitive data remains secure within your environment.
 
@@ -67,11 +89,11 @@ The second most critical feature is comprehensive log and event interrogation, m
 
 **Audit trail**: All actions performed through the inspector are logged for security and compliance purposes.
 
-### Optional Installation
+### Optional installation
 
 The Cluster Inspector capability can be **completely disabled** by not installing the inspector service component. This provides organizations with full control over cluster access and debugging capabilities.
 
-## Remote Replay and Data Collection
+## Remote replay and data collection
 
 Speedscale provides the ability to remotely inspect and control Kubernetes clusters similar to [k9s](https://k9scli.io/) or [lens](https://k8slens.dev/). Unlike these inspection tools, Speedscale also allows clusters to be used for *remote replay*. Clusters assigned to Speedscale in this way can run replays on demand and can be treated as a shared resource for engineers or testers.
 
@@ -105,21 +127,21 @@ Operator configuration is explained in greater detail in the [installation](../.
 
 ![workloads](./infra/workloads.png)
 
-The Workloads tab shows all workloads present in a namespace, and the status of any sidecars attached to those workloads. This is where the primary sidecar injection and management capabilities are accessed.
+The Workloads tab shows all workloads in a namespace and their capture status. New deployments should use eBPF capture. The sidecar fields remain visible for existing sidecar deployments.
 
 *Name* - Kubernetes name label for the workload
-*Injected* - true if the Speedscale sidecar is attached. Note that flipping this toggle will cause a sidecar to be injected.
-*TLS Out* - true if TLS Out unwrapping is enabled (highly desirable for mocking)
+*Injected* - true if the legacy Speedscale sidecar is attached
+*TLS Out* - true if legacy sidecar TLS unwrapping is enabled
 *Container Logs* - click to view the logs of the main workload container (enhanced debugging capability)
 *Sidecar Logs* - click to view the logs of the Speedscale sidecar (enhanced debugging capability)
 *Sidecar Health* - a simple alert/caution indicator for the sidecar configuration and recording health
 *Request CPU/Memory* - indicate how many resources are requested by the workload
 
-### Sidecar Management Best Practices
+### Capture management best practices
 - Start with non-critical workloads to validate configuration
-- Monitor resource usage after sidecar injection
-- Use selective deployment rather than cluster-wide injection
-- Regularly review and cleanup unused sidecars
+- Monitor [collector resource usage](/reference/ebpf-traffic-collection/resource-utilization) after enabling eBPF
+- Use selective workload targets rather than cluster-wide capture
+- Regularly review and remove capture targets that are no longer needed
 
 # Secrets
 
@@ -136,10 +158,10 @@ The list of Kubernetes network services available in the namespace, including:
 
 Similar to watching the logs, you can also view events. This provides enhanced debugging capabilities for remote users by centralizing event monitoring in a user-friendly interface. Pay attention to this section to detect pod problems like CrashLoopBackoff.
 
-**Enhanced Event Analysis Features:**
+**Event analysis features:**
 - Real-time event monitoring with filtering and search capabilities
 - Historical event analysis for troubleshooting past issues
-- Cross-reference events with workload and sidecar behavior
+- Cross-reference events with workload and collector behavior
 - Export capabilities for offline analysis
 
 # Replays
@@ -148,13 +170,13 @@ Similar to watching the logs, you can also view events. This provides enhanced d
 
 Use this tab to view currently running replays. Speedscale utilizes a Custom Resource Definition called a `trafficreplay` to manage cluster replays. This view shows CRDs in the namespace, whether currently active or not. Use the trash can icon to delete any running replays.
 
-**Active Traffic Replay Monitoring:**
+**Active traffic replay monitoring:**
 - Running test scenarios with real-time status
 - Traffic replay progress and completion indicators
 - Performance metrics and results analysis
 - Error rates and failure detection
 
-## Getting Started with Cluster Inspector
+## Getting started with Cluster Inspector
 
 ### Prerequisites
 
@@ -166,32 +188,32 @@ Use this tab to view currently running replays. Speedscale utilizes a Custom Res
 
 The Cluster Inspector is accessible through the Speedscale web interface under the **Observe** section. Navigate to your cluster view and select the cluster name to begin exploring your Kubernetes environment through the tabular interface.
 
-### Initial Setup
+### Initial setup
 
 1. **Verify permissions**: Ensure your user account has appropriate cluster access
 2. **Review workloads**: Start by exploring existing workloads and their current state
 3. **Identify candidates**: Select workloads that would benefit from traffic capture
-4. **Configure sidecars**: Use the Workloads tab to add Speedscale sidecars as needed
+4. **Configure capture**: Enable the eBPF collector and target the selected workloads
 
 ## Troubleshooting
 
-### Common Issues
+### Common issues
 
 **Inspector not accessible**: Verify the inspector service is installed and running in the cluster.
 
 **Missing workloads**: Check RBAC permissions and namespace access rights.
 
-**Sidecar injection failures**: Review workload compatibility and resource constraints.
+**Capture is missing**: Review the eBPF system requirements, target selectors, and nettap logs.
 
 **Log viewing problems**: Ensure proper logging drivers and log retention policies.
 
-### Debugging Workflows
-- Use the unified log view (Container Logs/Sidecar Logs) to correlate application and sidecar behavior
+### Debugging workflows
+- Use the unified log view to correlate application, Operator, and collector behavior
 - Filter events by workload or namespace to focus troubleshooting
 - Leverage historical data for pattern analysis
 - Export logs for offline analysis when needed
 
-### Getting Help
+### Getting help
 
 For technical support with the Cluster Inspector:
 - Check the Speedscale operator logs for error messages

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -34,8 +34,6 @@ flowchart LR
     outbound --> postgres["Postgres"]
 ```
 
-The Speedscale components are in orange and your components are in green.
-
 The curl HTTP client is used to make a request directly to the Speedscale proxy
 which forwards that request to your app, capturing the inbound request. Your
 app handles the inbound request and makes a database query to Postgres.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -136,7 +136,7 @@ window and your app should receive all requests from the snapshot.
 With `--daemon` flag, You can run generator and responder as a background process.  
 :::
 
-## Create local mocks
+## Create Local Mocks
 
 Local mocks are just another replay with no generator.
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -26,7 +26,13 @@ Speedscale [proxy](../reference/glossary.md#proxy).
 
 The traffic flow will look should look something like this:
 
-![traffic-flow](./cli/capture-flow.png)
+```mermaid
+flowchart LR
+    curl["curl"] --> inbound["Speedscale proxy<br/>inbound"]
+    inbound --> app["Your app"]
+    app --> outbound["Speedscale proxy<br/>outbound"]
+    outbound --> postgres["Postgres"]
+```
 
 The Speedscale components are in orange and your components are in green.
 
@@ -75,7 +81,13 @@ https://app.speedscale.com.
 Once you have captured traffic you can
 [create a snapshot](./creating-a-snapshot.md) and replay it against your app.
 
-![replay-flow](./cli/replay-flow.png)
+```mermaid
+flowchart LR
+    snapshot["Snapshot traffic"] -.-> generator["Generator"]
+    snapshot -.-> responder["Responder"]
+    generator --> app["Your app"]
+    app --> responder
+```
 
 The captured traffic is loaded into Speedscale components before the replay
 starts. The [generator](../reference/glossary.md#generator) makes requests to
@@ -124,7 +136,7 @@ window and your app should receive all requests from the snapshot.
 With `--daemon` flag, You can run generator and responder as a background process.  
 :::
 
-## Create Local Mocks
+## Create local mocks
 
 Local mocks are just another replay with no generator.
 

--- a/docs/guides/integrations/aws.md
+++ b/docs/guides/integrations/aws.md
@@ -12,9 +12,9 @@ Speedscale is a certified member of the AWS Partner Network (APN). This includes
 
 The Speedscale operator is compatible with AWS EKS (Elastic Kubernetes Service), versions v1.16 and newer.
 
-### Sidecar Capture Support
+### Traffic capture support
 
-The Speedscale sidecar is able to capture traffic sent to numerous AWS services including the following (note: not an exhaustive list):
+The Speedscale [eBPF collector](/reference/ebpf-traffic-collection) captures supported traffic sent to AWS services without adding a proxy to each workload. Supported services include the following (this list is not exhaustive):
 
 * API Gateway
 * DynamoDB

--- a/docs/guides/integrations/cicd/cicd.md
+++ b/docs/guides/integrations/cicd/cicd.md
@@ -15,7 +15,16 @@ deployment with confidence.
 Run Speedscale after your build and unit tests, but before deploying to
 production.
 
-![CI Pipeline](./cicd-flow.png)
+```mermaid
+flowchart LR
+    code["Code"] --> commit["Commit"]
+    commit --> build["Build"]
+    build --> unit["Unit tests"]
+    unit --> replay["Speedscale integration replay"]
+    replay --> review["Review"]
+    review --> staging["Staging"]
+    staging --> production["Production"]
+```
 
 Adding anything to your CI/CD pipeline generally involves the same 3 steps:
 

--- a/docs/guides/integrations/export/gatling.md
+++ b/docs/guides/integrations/export/gatling.md
@@ -59,7 +59,7 @@ speedctl export snapshot --type gatling --limit 50 --output MySimulation.java {S
    gatling.sh -sf src/test/java -s MySimulation
    ```
 
-## Generated script format
+## Generated Script Format
 
 The exported simulation uses Gatling's Java DSL and looks like this:
 
@@ -102,7 +102,7 @@ You can customize the generated script to add:
 - Assertions and checks
 - Feeders for parameterized data
 
-## Capturing transformed traffic
+## Capturing Transformed Traffic
 
 If you want to export traffic that has been processed by Speedscale transforms (e.g., JWT regeneration, data masking), you can capture the transformed output:
 

--- a/docs/guides/integrations/export/gatling.md
+++ b/docs/guides/integrations/export/gatling.md
@@ -59,7 +59,7 @@ speedctl export snapshot --type gatling --limit 50 --output MySimulation.java {S
    gatling.sh -sf src/test/java -s MySimulation
    ```
 
-## Generated Script Format
+## Generated script format
 
 The exported simulation uses Gatling's Java DSL and looks like this:
 
@@ -102,12 +102,12 @@ You can customize the generated script to add:
 - Assertions and checks
 - Feeders for parameterized data
 
-## Capturing Transformed Traffic
+## Capturing transformed traffic
 
 If you want to export traffic that has been processed by Speedscale transforms (e.g., JWT regeneration, data masking), you can capture the transformed output:
 
 1. Run a Speedscale replay with your transforms applied
-2. Attach a sidecar to capture the outgoing traffic as a new snapshot
+2. Enable [eBPF capture](/reference/ebpf-traffic-collection#enabling-via-annotation) on the application while the Speedscale generator is running
 3. Export the new snapshot to Gatling format
 
 This doesn't export the transform logic into the script, but it gives you the transformed request data.

--- a/docs/guides/integrations/export/grafana.md
+++ b/docs/guides/integrations/export/grafana.md
@@ -26,5 +26,5 @@ speedctl export snapshot --help
 Also feel free to ask questions on the [Community](https://slack.speedscale.com).
 
 :::tip
-If you want to capture transformed traffic you can do so by attaching a sidecar to your app while the Speedscale generator is running. This will capture the transformed traffic as a new snapshot which can be exported to k6. This does not export that actual logic into a script but it will let you export the end result.
+If you want to capture transformed traffic, enable [eBPF capture](/reference/ebpf-traffic-collection#enabling-via-annotation) on your app while the Speedscale generator is running. This records the transformed traffic as a new snapshot that can be exported to k6. The export contains the resulting requests, not the transform logic.
 :::

--- a/docs/guides/integrations/gcp.md
+++ b/docs/guides/integrations/gcp.md
@@ -14,8 +14,8 @@ The Speedscale operator is compatible with GCP GKE (Google Kubernetes Engine) Au
 
 ### GKE Autopilot
 
-Autopilot is an operational mode for GKE in which the entire cluster configuration, nodes, scaling, etc. are all managed by Google. It applies strict security policies — most notably, it does not allow pods with privileged containers — which changes how Speedscale captures traffic.
+Autopilot is an operational mode for GKE in which the entire cluster configuration, nodes, scaling, etc. are all managed by Google. Its strict security policies do not normally allow pods with privileged containers, which changes how Speedscale captures traffic.
 
-Speedscale supports two capture paths on Autopilot: **eBPF** (via a customer-owned WorkloadAllowlist) and a **sidecar in dual proxy mode** (transparent proxy is not supported). Both, along with the required Autopilot Helm values and per-workload annotations, are documented on the single dedicated page:
+Speedscale uses **eBPF** capture on Autopilot through a customer-owned WorkloadAllowlist. Existing deployments that cannot use eBPF can fall back to a **sidecar in dual proxy mode**; transparent proxy mode is not supported. Both paths and the required Autopilot Helm values are documented on the dedicated page:
 
 ➡️ **[GKE Autopilot install guide](/getting-started/installation/install/gke-autopilot)**

--- a/docs/guides/local-capture.md
+++ b/docs/guides/local-capture.md
@@ -22,7 +22,14 @@ This guide will walk you through recording an environment from your local deskto
 
    We use the bundled traffic driver to send requests to our sample app. Requests sent to the sample app will trigger an outbound call to the CNCF projects API at `demo-api.trafficreplay.com`.
 
-![architecture](./local-capture/demo_arch.png)
+```mermaid
+flowchart LR
+    driver["Traffic driver<br/>run_tests.sh or curl"] --> recorder["speedctl capture"]
+    recorder --> app["Sample app"]
+    app --> dependency["CNCF projects API"]
+    recorder -. "records inbound traffic" .-> app
+    app -. "outbound traffic through proxy" .-> recorder
+```
 
 ### Step 2: Start Speedscale Recording
 
@@ -77,7 +84,7 @@ MacOS users should add this certificate to the System keychain [settings](https:
    ./lab/tests/run_tests.sh --recording
    ```
 
-   The `--recording` flag sends requests to the speedctl capture port (`4143`) instead of the app's port (`8080`) so the traffic is intercepted. Any load tool works here (JMeter, k6, curl, etc.) — `run_tests.sh` is just the concrete example bundled with the demo.
+   The `--recording` flag sends requests to the speedctl capture port (`4143`) instead of the app's port (`8080`) so the traffic is intercepted. Any load tool works here (JMeter, k6, curl, etc.). `run_tests.sh` is the concrete example bundled with the demo.
 
 2. **Generate a variety of transactions**:
    - Run the script multiple times to record a richer set of transactions.
@@ -101,8 +108,6 @@ MacOS users should add this certificate to the System keychain [settings](https:
 Recorded environments, or Snapshots, contain the data necessary to clone an environment for a span of time. If you are doing general development and just need to mimic production services, consider a `mocks-only` replay setting. This will leave the mock server running so you can run different builds of your app against realistic services. If you want to run incoming client traffic over and over to reproduce an issue or for other development it's best to use a regular replay. This is more of a regression or load testing use case. Either can be done from the same recording.
 :::
 
-## Conclusion
+## Next step
 
-This guide demonstrates how to set up a Speedscale recording from your local desktop, enabling you to replicate an environment effortlessly and gain valuable insights into your application's behavior. Whether for testing or debugging, Speedscale provides a robust solution for managing and analyzing network traffic.
-
-Thank you for using Speedscale, and we hope this guide was helpful.
+Use the saved snapshot for a local mock-only replay or run it against a shared Kubernetes test environment.

--- a/docs/guides/mocking/llm-simulation.md
+++ b/docs/guides/mocking/llm-simulation.md
@@ -10,7 +10,7 @@ LLM simulation replaces live AI provider calls with recorded responses during de
 
 This works with both [Speedscale Cloud](#kubernetes-capture-with-speedscale-cloud) (for Kubernetes and staging environments) and [proxymock](#using-proxymock) (for local development and CI).
 
-## Why simulate LLM APIs?
+## Why Simulate LLM APIs?
 
 Most teams expect their AI bill to come from production traffic. In practice, a large portion comes from non-production activity: developers iterating on prompt wrappers, CI pipelines running the same scenarios on every pull request, and load tests hammering model endpoints in staging.
 
@@ -30,11 +30,11 @@ Real LLM calls add 500ms to 3s of latency per request. Mocked responses return i
 
 LLM responses vary between calls even with the same input. That non-determinism makes assertions difficult and causes flaky tests. Simulated responses are identical every time, giving you repeatable test results.
 
-### Rate limits
+### Rate Limits
 
 LLM providers enforce rate limits and token quotas. Load tests and batch CI runs can easily hit those limits, causing failures that have nothing to do with your application. Simulation avoids provider throttling entirely.
 
-## When to use real LLMs vs. simulation
+## When to Use Real LLMs vs. Simulation
 
 | Scenario | Use real LLM | Use simulation |
 |---|---|---|
@@ -48,7 +48,7 @@ LLM providers enforce rate limits and token quotas. Load tests and batch CI runs
 
 Use real providers when the goal is to evaluate the model itself: prompt quality, provider latency, output quality, or true cost. Use simulation when the goal is to test your application logic: response parsing, fallback handling, UI behavior, throughput, and retry logic.
 
-## Supported providers
+## Supported Providers
 
 Speedscale automatically detects and supports popular LLM provider APIs. No special configuration is required.
 
@@ -62,7 +62,7 @@ Speedscale automatically detects and supports popular LLM provider APIs. No spec
 
 Any HTTP-based LLM API will work even if it is not on this list. The auto-detection simply adds provider-specific labeling. See the full [technology support](../../reference/technology-support.md#supported-llm-providers) page for details.
 
-## How it works
+## How It Works
 
 LLM simulation follows the same capture-and-replay pattern as any other [service mock](./mocks.md), with one important difference: the captured data includes realistic AI responses, token counts, and latency rather than hand-written stubs.
 
@@ -76,7 +76,7 @@ Sensitive values like provider API keys are automatically redacted so the captur
 
 Speedscale Cloud captures and replays LLM traffic in Kubernetes environments using the Operator and eBPF collector.
 
-### Capture LLM traffic
+### Capture LLM Traffic
 
 Enable eBPF capture for your service. When your application makes outbound calls to LLM providers, the collector records supported HTTP and TLS traffic without adding a proxy to the workload.
 
@@ -91,7 +91,7 @@ The captured traffic includes the internal service calls (like a tools service o
 You only need one good recording. Run the workflow with all the providers and scenarios you care about, then reuse that snapshot indefinitely.
 :::
 
-### Replay with mocked LLMs
+### Replay with Mocked LLMs
 
 Once you have a snapshot, replay uses the Speedscale responder to serve recorded LLM responses:
 
@@ -99,7 +99,7 @@ Once you have a snapshot, replay uses the Speedscale responder to serve recorded
 - **Load testing** -- Configure a [load test](../replay/load-test.md) to multiply the traffic. The responder serves LLM mocks at any scale with no provider cost and no rate limiting.
 - **CI integration** -- Add replay to your [CI/CD pipeline](../integrations/cicd/cicd.md) so every pull request validates the LLM integration without live calls.
 
-### Customizing signatures
+### Customizing Signatures
 
 Speedscale generates good default signatures for LLM requests. If you need to adjust matching behavior -- for example, ignoring a timestamp field in the prompt or wildcarding a model version in the URL -- see the [modifying signatures](./modifying.md) guide.
 
@@ -127,7 +127,7 @@ proxymock mock --in ./proxymock
 
 Your application makes the same outbound calls, but proxymock intercepts them and returns the recorded responses. Zero cost, instant responses, fully deterministic.
 
-### CI integration
+### CI Integration
 
 Commit the `proxymock/` snapshot directory to your repository. In CI, run proxymock in mock mode before starting your tests. No API keys are needed in the CI environment.
 
@@ -138,13 +138,13 @@ proxymock mock --in ./proxymock &
 
 See the full [proxymock LLM simulation guide](/proxymock/guides/llm-simulation.md) for a step-by-step walkthrough, and the [proxymock CI/CD guide](/proxymock/guides/cicd.md) for pipeline setup.
 
-## Demo application
+## Demo Application
 
 The [LLM simulation demo](https://github.com/speedscale/demo/tree/master/llm-simulation-demo) is a support-ticket triage application that demonstrates this pattern end to end.
 
 The demo runs a 3-step AI pipeline (triage, analysis, response drafting) against OpenAI, Anthropic, Gemini, and xAI/Grok. It includes 20 sample tickets and tracks timing, token usage, and projected cost per run. With 4 providers enabled, a single "Analyze All" run makes 240 LLM API calls -- exactly the kind of repetitive non-production traffic that simulation eliminates.
 
-## Further reading
+## Further Reading
 
 - [Service Mocking concepts](../../concepts/service_mocking.md) -- how Speedscale service mocking works
 - [Signature Matching](./signature.md) -- how requests are matched to recorded responses

--- a/docs/guides/mocking/llm-simulation.md
+++ b/docs/guides/mocking/llm-simulation.md
@@ -8,9 +8,9 @@ sidebar_position: 6
 
 LLM simulation replaces live AI provider calls with recorded responses during development, CI, and load testing. Instead of paying for real model inference every time a developer refreshes a screen or a CI pipeline runs, you capture one real interaction and replay it everywhere else.
 
-This works with both [Speedscale Cloud](#using-speedscale-cloud) (for Kubernetes and staging environments) and [proxymock](#using-proxymock) (for local development and CI).
+This works with both [Speedscale Cloud](#kubernetes-capture-with-speedscale-cloud) (for Kubernetes and staging environments) and [proxymock](#using-proxymock) (for local development and CI).
 
-## Why Simulate LLM APIs?
+## Why simulate LLM APIs?
 
 Most teams expect their AI bill to come from production traffic. In practice, a large portion comes from non-production activity: developers iterating on prompt wrappers, CI pipelines running the same scenarios on every pull request, and load tests hammering model endpoints in staging.
 
@@ -30,11 +30,11 @@ Real LLM calls add 500ms to 3s of latency per request. Mocked responses return i
 
 LLM responses vary between calls even with the same input. That non-determinism makes assertions difficult and causes flaky tests. Simulated responses are identical every time, giving you repeatable test results.
 
-### Rate Limits
+### Rate limits
 
 LLM providers enforce rate limits and token quotas. Load tests and batch CI runs can easily hit those limits, causing failures that have nothing to do with your application. Simulation avoids provider throttling entirely.
 
-## When to Use Real LLMs vs. Simulation
+## When to use real LLMs vs. simulation
 
 | Scenario | Use real LLM | Use simulation |
 |---|---|---|
@@ -48,7 +48,7 @@ LLM providers enforce rate limits and token quotas. Load tests and batch CI runs
 
 Use real providers when the goal is to evaluate the model itself: prompt quality, provider latency, output quality, or true cost. Use simulation when the goal is to test your application logic: response parsing, fallback handling, UI behavior, throughput, and retry logic.
 
-## Supported Providers
+## Supported providers
 
 Speedscale automatically detects and supports popular LLM provider APIs. No special configuration is required.
 
@@ -62,7 +62,7 @@ Speedscale automatically detects and supports popular LLM provider APIs. No spec
 
 Any HTTP-based LLM API will work even if it is not on this list. The auto-detection simply adds provider-specific labeling. See the full [technology support](../../reference/technology-support.md#supported-llm-providers) page for details.
 
-## How It Works
+## How it works
 
 LLM simulation follows the same capture-and-replay pattern as any other [service mock](./mocks.md), with one important difference: the captured data includes realistic AI responses, token counts, and latency rather than hand-written stubs.
 
@@ -72,16 +72,16 @@ LLM simulation follows the same capture-and-replay pattern as any other [service
 
 Sensitive values like provider API keys are automatically redacted so the captured data is safe to store, share, and commit to version control.
 
-## Using Speedscale Cloud
+## Kubernetes capture with Speedscale Cloud
 
-Speedscale Cloud captures and replays LLM traffic in Kubernetes environments using the operator and sidecar.
+Speedscale Cloud captures and replays LLM traffic in Kubernetes environments using the Operator and eBPF collector.
 
-### Capture LLM Traffic
+### Capture LLM traffic
 
-Deploy the Speedscale sidecar to your service. When your application makes outbound calls to LLM providers, the sidecar records them transparently -- no code changes required.
+Enable eBPF capture for your service. When your application makes outbound calls to LLM providers, the collector records supported HTTP and TLS traffic without adding a proxy to the workload.
 
 1. [Install the operator](../../getting-started/installation/install/kubernetes-operator.md) if you have not already.
-2. Add the Speedscale sidecar annotation to your deployment.
+2. [Enable the eBPF collector](../../reference/ebpf-traffic-collection/README.md#installation) and target your deployment.
 3. Run your workflow once with real provider API keys configured.
 4. Open the snapshot in the Speedscale UI. You will see each LLM API call with its full request and response.
 
@@ -91,7 +91,7 @@ The captured traffic includes the internal service calls (like a tools service o
 You only need one good recording. Run the workflow with all the providers and scenarios you care about, then reuse that snapshot indefinitely.
 :::
 
-### Replay with Mocked LLMs
+### Replay with mocked LLMs
 
 Once you have a snapshot, replay uses the Speedscale responder to serve recorded LLM responses:
 
@@ -99,7 +99,7 @@ Once you have a snapshot, replay uses the Speedscale responder to serve recorded
 - **Load testing** -- Configure a [load test](../replay/load-test.md) to multiply the traffic. The responder serves LLM mocks at any scale with no provider cost and no rate limiting.
 - **CI integration** -- Add replay to your [CI/CD pipeline](../integrations/cicd/cicd.md) so every pull request validates the LLM integration without live calls.
 
-### Customizing Signatures
+### Customizing signatures
 
 Speedscale generates good default signatures for LLM requests. If you need to adjust matching behavior -- for example, ignoring a timestamp field in the prompt or wildcarding a model version in the URL -- see the [modifying signatures](./modifying.md) guide.
 
@@ -127,7 +127,7 @@ proxymock mock --in ./proxymock
 
 Your application makes the same outbound calls, but proxymock intercepts them and returns the recorded responses. Zero cost, instant responses, fully deterministic.
 
-### CI Integration
+### CI integration
 
 Commit the `proxymock/` snapshot directory to your repository. In CI, run proxymock in mock mode before starting your tests. No API keys are needed in the CI environment.
 
@@ -138,13 +138,13 @@ proxymock mock --in ./proxymock &
 
 See the full [proxymock LLM simulation guide](/proxymock/guides/llm-simulation.md) for a step-by-step walkthrough, and the [proxymock CI/CD guide](/proxymock/guides/cicd.md) for pipeline setup.
 
-## Demo Application
+## Demo application
 
 The [LLM simulation demo](https://github.com/speedscale/demo/tree/master/llm-simulation-demo) is a support-ticket triage application that demonstrates this pattern end to end.
 
 The demo runs a 3-step AI pipeline (triage, analysis, response drafting) against OpenAI, Anthropic, Gemini, and xAI/Grok. It includes 20 sample tickets and tracks timing, token usage, and projected cost per run. With 4 providers enabled, a single "Analyze All" run makes 240 LLM API calls -- exactly the kind of repetitive non-production traffic that simulation eliminates.
 
-## Further Reading
+## Further reading
 
 - [Service Mocking concepts](../../concepts/service_mocking.md) -- how Speedscale service mocking works
 - [Signature Matching](./signature.md) -- how requests are matched to recorded responses

--- a/docs/guides/production-readiness.md
+++ b/docs/guides/production-readiness.md
@@ -11,13 +11,19 @@ Use [sidecar capture](/getting-started/installation/sidecar/install) only for an
 
 ## Preparation Checklist
 
+- [ ] Sign the Speedscale SaaS agreement.
 - [ ] Confirm the target clusters, namespaces, and workloads.
 - [ ] Confirm that cluster nodes meet the eBPF requirements.
+- [ ] Check for a service mesh or other cluster security controls.
 - [ ] Size the Operator, forwarder, and nettap for the expected traffic volume.
 - [ ] Decide whether to disable remote control.
 - [ ] Configure data loss prevention and traffic filters.
 - [ ] Restrict access to Kubernetes secrets if required.
 - [ ] Define rollout and rollback criteria.
+
+### Sign the SaaS agreement
+
+Speedscale requires a signed SaaS agreement for a commercial license before it will support a production deployment.
 
 ### Scope the initial target
 
@@ -30,6 +36,10 @@ Target workloads with namespace and pod selectors in the Operator Helm values, o
 Confirm the supported Kubernetes version, Linux kernel, container runtime, protocols, and TLS libraries before installation. If the workload uses TLS, check [TLS traffic visibility](/reference/ebpf-traffic-collection#tls-traffic-visibility) for language-specific requirements.
 
 The collector is a privileged DaemonSet. Review its security context, host mounts, and required capabilities with the platform and security teams. Managed Kubernetes platforms can require additional admission configuration. For example, see the [GKE Autopilot guide](/getting-started/installation/install/gke-autopilot).
+
+Istio and its derivatives are supported natively. If you run Istio, follow the [Istio installation notes](../getting-started/installation/install/istio.md) while configuring the Operator. For any other service mesh, contact [support](https://slack.speedscale.com) before you start.
+
+Ask your security team whether cluster-level security tooling is in place. Admission controllers and runtime security agents can block the collector's privileged DaemonSet, and the failures present as obscure timeouts rather than clear denials. Namespaces such as `twistlock` or `calico-` are a hint that such tools are installed. Speedscale has recipes for coexisting with many of them; ask support.
 
 ### Disable remote control when required
 
@@ -59,6 +69,7 @@ Use [traffic filters](/guides/creating-filters) to exclude health checks, monito
 
 ## Deployment Checklist
 
+- [ ] Scope the Operator to the namespaces it needs.
 - [ ] Install the Operator and enable eBPF.
 - [ ] Apply a narrow capture target.
 - [ ] Confirm the collector and forwarder are healthy.
@@ -66,6 +77,20 @@ Use [traffic filters](/guides/creating-filters) to exclude health checks, monito
 - [ ] Validate redaction, filtering, and TLS decoding.
 - [ ] Measure resource use and application latency.
 - [ ] Expand the target set gradually.
+
+### Scope the Operator with a namespace selector
+
+The Operator installs a mutating webhook that runs on every deployment in the cluster. Restrict it to a subset of namespaces with the `namespaceSelector` Helm value. This also changes the RBAC the chart creates:
+
+- A `ClusterRole` and `ClusterRoleBinding` named `speedscale-operator` is always created. It always carries the minimal permissions the Operator needs to function, such as listing namespaces, webhooks, and its own role.
+- Without a namespace selector, that `ClusterRole` also gets permission to read and modify `deployments`, `statefulsets`, `daemonsets`, `secrets`, and similar resources across the whole cluster.
+- With a namespace selector, those broader permissions move into a `Role` and `RoleBinding` created in each selected namespace instead, so the Operator has no access outside them.
+
+:::tip
+A `ClusterRole` is a non-namespaced resource granting permissions across the entire cluster. A `Role` is namespaced and grants permissions only within its own namespace.
+:::
+
+Security reviewers usually want the namespace-scoped form for production. The exact resources and verbs are in `rbac.yaml` in the [chart templates](https://github.com/speedscale/operator-helm).
 
 ### Install and target eBPF capture
 

--- a/docs/guides/production-readiness.md
+++ b/docs/guides/production-readiness.md
@@ -1,290 +1,137 @@
 ---
-description: "Prepare for production with Speedscale by exploring essential considerations for recording in a production environment using the Speedscale sidecar."
+description: "Prepare a Speedscale eBPF traffic capture deployment for a safe production rollout."
 sidebar_position: 20
 ---
 
-# Production Readiness
+# Production readiness
 
-:::warning Sidecar capture is deprecated
-This guide is retained for existing sidecar deployments. For new Kubernetes installations, start with the [eBPF collector](/reference/ebpf-traffic-collection) and review its [workload impact](/reference/ebpf-traffic-collection/workload-impact) before production rollout.
-:::
+Use the Speedscale eBPF collector for new Kubernetes production deployments. It observes traffic from each node without injecting a proxy into application pods or adding a network hop. Review the [eBPF system requirements](/reference/ebpf-traffic-collection#system-requirements) and [workload impact](/reference/ebpf-traffic-collection/workload-impact) before rollout.
 
-This guide is a comprehensive walkthrough of considerations for existing production environments that record with the Speedscale sidecar. If you are using an environment other than Kubernetes, this guide may be helpful but much of it will not be relevant. Contact [support](https://slack.speedscale.com) for help tailoring these instructions to your environment.
+Use [sidecar capture](/getting-started/installation/sidecar/install) only for an existing deployment or a workload that does not meet the eBPF requirements.
 
-Prior to reading this guide it may be beneficial to learn about how Speedscale's [architecture](../reference/architecture.md) to have a clear idea of all the moving parts.
+## Preparation checklist
 
-This guide is designed to be comprehensive and is broken into three sections:
+- [ ] Confirm the target clusters, namespaces, and workloads.
+- [ ] Confirm that cluster nodes meet the eBPF requirements.
+- [ ] Size the Operator, forwarder, and nettap for the expected traffic volume.
+- [ ] Decide whether to disable remote control.
+- [ ] Configure data loss prevention and traffic filters.
+- [ ] Restrict access to Kubernetes secrets if required.
+- [ ] Define rollout and rollback criteria.
 
-1. Preparation
-2. Deployment
-3. Validation
+### Scope the initial target
 
-By the end, you will have weighed security concerns, ensured minimal application impact and learned safe deployment strategies.
+Speedscale records only the workloads selected by the eBPF capture configuration. Start with one representative service and a limited traffic window. Expand to additional workloads after validating capture quality, resource use, data controls, and ingest volume.
 
-## Preparation Checklist
+Target workloads with namespace and pod selectors in the Operator Helm values, or use the `capture.speedscale.com/enabled` annotation. See [eBPF traffic collection](/reference/ebpf-traffic-collection#enabling-via-helm) for both options.
 
-- [ ] SaaS Agreement
-- [ ] Assess your Environment
-- [ ] Roles
-- [ ] Remote Control
-- [ ] Data Loss Prevention (PII)
-- [ ] Secret Access Control
+### Review cluster and workload requirements
 
-### SaaS Agreement
+Confirm the supported Kubernetes version, Linux kernel, container runtime, protocols, and TLS libraries before installation. If the workload uses TLS, check [TLS traffic visibility](/reference/ebpf-traffic-collection#tls-traffic-visibility) for language-specific requirements.
 
-Ensure that you have signed the Speedscale SaaS agreement for a commercial license. Speedscale requires this for production deployment support.
+The collector is a privileged DaemonSet. Review its security context, host mounts, and required capabilities with the platform and security teams. Managed Kubernetes platforms can require additional admission configuration. For example, see the [GKE Autopilot guide](/getting-started/installation/install/gke-autopilot).
 
-### Assess your Environment
+### Disable remote control when required
 
-The Speedscale sidecar is highly adaptable but does require some configuration. Answer these questions first:
+Speedscale can optionally accept control-plane commands from the web application. For production recording clusters that require all changes to pass through Kubernetes RBAC and GitOps, set `dashboardAccess: false` in the Operator Helm values. This prevents the remote-control container from being deployed.
 
-- [ ] Which services do you want to record from?
+With remote control disabled, manage capture targets and replays through cluster configuration.
 
-Speedscale will not automatically record everything in your cluster. By default, individual services must be targeted for recording. Make a list of services you want to target.
+### Configure data loss prevention
 
-- [ ] Are you running on Kubernetes?
+[Data loss prevention (DLP)](/guides/dlp) filters and redacts traffic before it leaves the cluster. Test DLP rules in a non-production cluster with representative traffic before applying them to production.
 
-If you are not running on Kubernetes then most of these instructions will need to be customized for your environment. It isn't necessarily difficult but [support](https://slack.speedscale.com) is happy to help.
+A safe validation sequence is:
 
-- [ ] Are you utilizing a Service Mesh?
+1. Copy the `standard` DLP rule and add the fields that must be redacted.
+2. Install or upgrade the Operator with `dlp.enabled: true` and set `dlp.config` to the custom rule.
+3. Enable capture for one workload.
+4. Confirm that sensitive fields are redacted in the Traffic Viewer.
+5. Add remaining rules and repeat the check.
 
-Istio and its derivatives are currently supported natively. Other service meshes may be supported if you contact [support](https://slack.speedscale.com). If you are using Istio you will need to follow the instructions in this [section](../getting-started/installation/install/istio.md) while configuring the operator. Just save that link for later.
+### Restrict secret access
 
-- [ ] Does your cluster have resources to support the extra recording workload?
+The Operator can read Kubernetes secrets for transforms such as JWT resigning. Use the `secretAccessList` Helm value to restrict access to the specific secrets required by your replay workflows. An empty list allows access to all secrets in the configured namespaces.
 
-Speedscale is optimized for application latency impact, CPU impact and then memory impact. Speedscale engineering optimizes the sidecar in this order to give maximum control and flexibility to users. For instance, the Speedscale sidecar will sacrifice memory and CPU usage to prevent it from impacting the application. However, recording does require some resources and we will size them later in this guide. As seen with similar projects like Envoy, we aim for maximum efficiency but the work still needs to be done somewhere.
+### Filter traffic before ingest
 
-- [ ] Do you have security tools in place that will prevent Speedscale from working properly?
+Use [traffic filters](/guides/creating-filters) to exclude health checks, monitoring traffic, large payloads, and out-of-scope services before data is sent to Speedscale Cloud. Start from the `standard` filter and add environment-specific rules. Filtering is also the primary control for limiting ingest volume and network egress.
 
-Sidecars require network manipulation. Some security tools are installed at the cluster level that prevent north-south and/or even east/west communication between pods. These issues can be very hard to diagnose because they present as obscure network timeouts. It is beneficial to ask your security team if any of these tools are installed. Alternatively, you can look at the other namespaces in the cluster to get a hint. If you see things like `twistlock` or `calico-` then it is possible these tools are present and configured to prevent certain activities. Speedscale has recipes for dealing with many security tools while preserving cluster security. These are available on demand from support.
+## Deployment checklist
 
-### Roles
+- [ ] Install the Operator and enable eBPF.
+- [ ] Apply a narrow capture target.
+- [ ] Confirm the collector and forwarder are healthy.
+- [ ] Generate representative traffic.
+- [ ] Validate redaction, filtering, and TLS decoding.
+- [ ] Measure resource use and application latency.
+- [ ] Expand the target set gradually.
 
-Are you directly responsible for modifying your production cluster? If not, send this guide to your DevOps/SRE/Platform Eng team early and let them think through what changes need to be made. Production deployment requires balancing many concerns and the SRE job description typically does not include the bullet "enjoys surprises."
+### Install and target eBPF capture
 
-### Remote Control
+Enable the collector in the Operator Helm values and define an initial target:
 
-Speedscale is designed to be installed in the cluster and then (optionally) remotely controlled by users that do not have access to the cluster. This is done so that the DevOps/SRE/Platform Engineering teams are not constantly working on the cluster for day-to-day activities. Regular engineers can perform their work independently in this mode as long as they stay in allowed lanes. However, while this works very well for clusters that are intended for simulation, it is overly permissive for most production environment.
-
-For clusters solely used for production recording, Speedscale recommends disabling remote control for security purposes. In this mode, CRs or Annotations must be applied directly to the cluster to both add sidecars and initiate replays. Forcing all changes to be done by a user with appropriate Kubernetes RBAC permissions may make it harder to make changes, the tradeoff is usually worth it for prod.
-
-All Remote Control functionality is wrapped in a completely separate container. When it is turned off, this container is not deployed and so no remote execution functionality is even present.
-
-To disable Remote Control you set `dashboardAccess` to `false` in the Speedscale helm chart. The default value is `true`
-
-[https://github.com/speedscale/operator-helm/blob/main/values.yaml#L33](https://github.com/speedscale/operator-helm/blob/main/values.yaml#L33)
-
-### Data Loss Prevention
-
-Speedscale can be configured to redact sensitive data and personally identifiable information (PII) from traffic via it's data loss prevention (DLP) features. This redaction happens *before* data leaves your network, preventing Speedscale from seeing the data at all. Most customers test their DLP configuration in another cluster before applying to production.
-
-[Data Loss Prevention (DLP) | Speedscale Docs](https://docs.speedscale.com/guides/dlp/)
-
-https://github.com/speedscale/operator-helm/blob/main/values.yaml#L38
-
-This is the ideal process for validating DLP settings:
-
-1. Create a DLP Rule (it can be blank to start with). The purpose of this is to redact specific fields that are being sent (ex: an authorization token or user email address)
-2. Install Speedscale via the helm chart and set:
-   1. `dlp.enabled` to `true`
-   2. `dlp.config` to the name of your custom DLP Rule
-3. Confirm in the logs of the operator that your DLP rules are used.
-4. Install the sidecar on the micro service.
-5. Add a DLP rule to redact a given field
-   1. You should see this causes the forwarder to restart with the new rule being applied.
-   2. Validate the field is redacted
-   3. Repeat as needed for multiple fields
-
-Once this process is complete you have a DLP configuration that can be used in production.
-
-### Secret Access Control
-
-In highly secure environments, you may want to restrict which Kubernetes secrets Speedscale can access during testing. Speedscale uses secrets as variables for various transforms, such as JWT resigning. The `secretAccessList` parameter in the Speedscale Operator helm chart controls this access:
-
-- **Empty list (default)**: Grants access to all secrets in the cluster
-- **Populated list**: Limits access to only the specified secrets
-
-[https://github.com/speedscale/operator-helm/blob/main/values.yaml#L41](https://github.com/speedscale/operator-helm/blob/main/values.yaml#L41)
-
-For production environments requiring strict security controls, configure `secretAccessList` with only the secrets that Speedscale needs for testing operations. This provides granular control over secret access while maintaining Speedscale's ability to perform necessary testing operations.
-
-### Traffic Filtering
-
-Filter rules can be used to completely block traffic from ever being sent to Speedscale (ex: health checks or monitoring systems or data that is out of scope for your use case). You can create a Filter Rule (we recommend you copy `standard` and add your settings to it).
-
-[https://github.com/speedscale/operator-helm/blob/main/values.yaml#L35](https://github.com/speedscale/operator-helm/blob/main/values.yaml#L35)
-
-Once this process is complete you have a Filter configuration that can be used in production. Keep in mind that this is one of the best ways to control your ingest volume and reduce network egress traffic.
-
-:::note
-Filter rules can be tuned after deployment but if Remote Control is turned off it may require cluster access.
-:::
-
-## Deployment Checklist
-
-- [ ] Operator Customization
-- [ ] Forwarder Resources
-- [ ] Pod Sampling and Rollout
-
-In this section we will deploy the operator and then show you a strategy on how to set up a canary deployment for only part of your application traffic. This guide assumes you are already familiar with the Speedscale helm [chart](https://github.com/speedscale/operator-helm) and [helm](https://helm.sh/docs/intro/using_helm/) deployment workflow.
-
-### Operator Customization
-
-The [chart](https://github.com/speedscale/operator-helm) chart will install a mutating webhook that is called any time a deployment occurs in the cluster. You can scope this to a subset of namespaces by setting `namespaceSelector` [here](https://github.com/speedscale/operator-helm/blob/main/values.yaml#L29).
-
-#### Namespace Selector RBAC
-
-When using a namespace selector, the Helm chart sets up RBAC resources to ensure the operator and any other components do not have permissions to access things outside of the specified namespaces. The specific resources and permissions created can be viewed in the `rbac.yaml` file of the Helm templates but the summary is:
-
-- A `ClusterRole` and corresponding `ClusterRoleBinding` called `speedscale-operator` is always created.
-- This `ClusterRole` always has permissions to list namespaces, webhooks, its own role, etc. for minimal functionality.
-- If a namespace selector is not specified, the `ClusterRole` also has permissions to read and modify all `deployments`, `statefulsets`, `daemonsets`, `secrets`, etc
-- If a namespace selector is specified, a `Role` and corresponding `RoleBinding` is created in each specified namespace with the same set of permissions relating to `deployments`, `statefulsets`, etc.
-
-:::tip
-
-`ClusterRole`'s are non-namespaced resources that specify permissions across the entire cluster while `Role`'s are namespaced resources that only specify permissions for that specific namespace
-
-:::
-
-#### Resources
-
-In a large environment with hundreds or thousands of deployments, the operator may need additional resources, you can increase the resources in the helm chart.
-
-[https://github.com/speedscale/operator-helm/blob/main/values.yaml#L93](https://github.com/speedscale/operator-helm/blob/main/values.yaml#L93)
-
-The fastest way to know the operator is resource constrained is to check the resources used vs limits in your monitoring dashboard. Alerts may also appear in the Infrastructure section of the Speedscale UI.
-
-### Forwarder Resources
-
-In a large environment with hundreds of gigs of traffic, the forwarder may need additional resources, you can increase the resources in the helm chart:
-
-[https://github.com/speedscale/operator-helm/blob/main/values.yaml#L124](https://github.com/speedscale/operator-helm/blob/main/values.yaml#L124)
-
-The fastest way to know the forwarder is resource constrained is to check the resources used vs limits in your monitoring dashboard. Alerts may also appear in the Infrastructure section of the Speedscale UI.
-
-### Sidecar Customization
-
-Assuming Remote Control is disabled, you will apply the sidecar using either annotations or the `trafficreplay` CR.
-
-On an application with very high throughput, the sidecar may need additional resources, you can customize the sidecar resources that are used by default on each sidecar by customizing the helm chart:
-
-[https://github.com/speedscale/operator-helm/blob/main/values.yaml#L104](https://github.com/speedscale/operator-helm/blob/main/values.yaml#L104)
-
-In addition to the resources, there are numerous other ways to customize the sidecar. For example if there is traffic that is not required, you can completely block that port or host. There is a complete set of annotations for customization here:
-
-[https://docs.speedscale.com/getting-started/installation/sidecar/annotations/](https://docs.speedscale.com/getting-started/installation/sidecar/annotations/)
-
-## Pod Sampling
-
-See the [FAQ](/reference/faq.md) for more information about Speedscale capabilities.
-
-Sampling or "canary deployment" is an effective way to limit the blast radius of any change. There are multiple ways to configure sampling for pods that are built into Kubernetes. Here are 2 options:
-
-1. Additional Deployments with same label
-2. Using Istio Traffic Management (if deployed)
-
-### Deployments with Label
-
-Let’s say you have a simple deployment with 3 replicas:
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: frontend
-  labels:
-    app: frontend
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: frontend
-  template:
-    metadata:
-      labels:
-        app: frontend
-    spec:
-      containers:
-        - name: frontend
-          image: gcr.io/speedscale-demos/frontend:latest
-          imagePullPolicy: Always
-          ports:
-            - containerPort: 8080
+```yaml title="production-values.yaml"
+ebpf:
+  enabled: true
+  configuration:
+    capture:
+      targets:
+        - name: checkout
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: production
+          podSelector:
+            matchLabels:
+              app: checkout
 ```
 
-And a simple service that will route to those 3 replicas:
-
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: frontend
-  labels:
-    app: frontend
-spec:
-  type: ClusterIP
-  ports:
-    - name: http
-      port: 80
-      targetPort: 8080
-  selector:
-    app: frontend
-```
-
-It is possible to create an additional deployment with a different name but the same labels, and in addition this has the sidecar:
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-  name: frontend-sidecar
-  labels:
-    app: frontend
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: frontend
-  template:
-    metadata:
-      labels:
-        app: frontend
-    spec:
-      containers:
-        - name: frontend
-          image: gcr.io/speedscale-demos/frontend:latest
-          imagePullPolicy: Always
-          ports:
-            - containerPort: 8080
-```
-
-Now you have a total of 4 pods, 3 of them without the sidecar and 1 with the sidecar. This is a very simple way to set up sampling. However, if you have a complex environment with pod autoscaling this may change the distribution of how much traffic is sampled.
+Add these values to the normal [Operator installation](/getting-started/installation/install/kubernetes-operator). For an existing installation, apply them with an upgrade:
 
 ```bash
-$ kubectl -n microservices-istio get pods -l app=frontend
-NAME                                READY   STATUS    RESTARTS   AGE
-frontend-68ff688844-2n4tk           2/2     Running   0          38s
-frontend-68ff688844-rjdn8           2/2     Running   0          60s
-frontend-68ff688844-rrmtg           2/2     Running   0          82s
-frontend-sidecar-5f4fc8f8c8-xfnll   3/3     Running   0          70s
+helm upgrade speedscale-operator speedscale/speedscale-operator \
+  --namespace speedscale \
+  --reuse-values \
+  -f production-values.yaml
 ```
 
-Here you can see only the pod called `frontend-sidecar` has `3/3` containers, and the others have `2/2` containers (only istio and the application).
+For an existing Operator installation, you can instead enable a deployment with an annotation:
 
-### (optional) Istio Traffic Management
+```bash
+kubectl annotate deployment checkout -n production \
+  capture.speedscale.com/enabled="true" --overwrite
+```
 
-Because deployment is highly customizable, it is recommended that the DevOps/SRE/Platform Eng team utilize a well-known pattern for canary deployments, then split the traffic among these. This is a more sophisticated way to handle the routing and you can ensure that a specific % of the traffic is going to the pods with the sidecars. Use this instead of the manual process in the previous section.
+### Size the in-cluster components
 
-Take a look at Istio's official guide and tailor to your environment.
-[Traffic Management](https://istio.io/latest/docs/concepts/traffic-management/)
+Monitor CPU, memory, restarts, and throttling for the Operator, forwarder, and nettap during the initial recording window. Increase the relevant Helm resource requests and limits if components approach their limits. The forwarder needs enough capacity for filtering, DLP, and compression at the expected traffic rate.
+
+Because nettap runs once per selected node, compare node resource use before and after enabling the target. The [workload impact guide](/reference/ebpf-traffic-collection/workload-impact) provides a repeatable measurement procedure.
+
+### Expand in stages
+
+Add workloads in small groups after the initial target passes validation. Prefer selectors that identify stable application labels. Avoid revision-specific labels that change with each deployment.
+
+If only a percentage of traffic should be captured, route that percentage to a canary deployment and target the canary's stable labels. Use the platform's normal canary or service-mesh traffic management rather than injecting a separate capture proxy.
 
 ## Validation
 
-At this point you should have the operator deployed (via helm) and at least a canary sidecar deployment. It's wise to take a moment to check resource utilization and functionality before going further.
+Confirm each of these before expanding production capture:
 
-Open your normal Kubernetes monitoring solution and check CPU/Memory utilization versus the assigned limits. If the limits are being exceeded then you will need to modify the helm chart to increase available limits. If you do not have a monitoring solution we recommend [k9s](https://github.com/derailed/k9s) as a fast and pleasant option. You should verify the operator, forwarder and sidecars to be sure.
+- The nettap DaemonSet is ready on every node that hosts a target workload.
+- Captured traffic is attributed to the expected service and namespace.
+- Supported TLS traffic is decoded and long-lived connections were restarted after probes attached.
+- DLP rules redact sensitive fields before upload.
+- Filters exclude health checks, monitoring traffic, and other known noise.
+- Operator, nettap, and forwarder resource use remains within limits.
+- Application latency and error rates remain within the agreed rollout threshold.
+- Ingest volume matches the expected traffic sample.
 
-Next, check your application latency vs historical averages to make sure the impact is not unexpected. Keep in mind that some small latency impact is normal. If you're seeing excessive latency we have an extensive diagnostics [metrics](../getting-started/installation/sidecar/performance.md) guide. As always, feel free to reach out to [support](https://slack.speedscale.com).
+To stop capture for an annotation-based target:
+
+```bash
+kubectl annotate deployment checkout -n production \
+  capture.speedscale.com/enabled="false" --overwrite
+```
+
+For selector-based targets, remove the target from the Operator Helm values and apply the updated configuration. Contact [Speedscale support](https://slack.speedscale.com) if the rollout does not meet the validation criteria.

--- a/docs/guides/production-readiness.md
+++ b/docs/guides/production-readiness.md
@@ -37,7 +37,7 @@ Confirm the supported Kubernetes version, Linux kernel, container runtime, proto
 
 The collector is a privileged DaemonSet. Review its security context, host mounts, and required capabilities with the platform and security teams. Managed Kubernetes platforms can require additional admission configuration. For example, see the [GKE Autopilot guide](/getting-started/installation/install/gke-autopilot).
 
-Istio and its derivatives are supported natively. If you run Istio, follow the [Istio installation notes](../getting-started/installation/install/istio.md) while configuring the Operator. For any other service mesh, contact [support](https://slack.speedscale.com) before you start.
+Istio and its derivatives are supported natively. If you run Istio, follow the [external networking requirements](/getting-started/installation/install/istio#external-networking-requirements) while configuring the Operator. The sidecar configuration on that page applies only to legacy sidecar capture. For any other service mesh, contact [support](https://slack.speedscale.com) before you start.
 
 Ask your security team whether cluster-level security tooling is in place. Admission controllers and runtime security agents can block the collector's privileged DaemonSet, and the failures present as obscure timeouts rather than clear denials. Namespaces such as `twistlock` or `calico-` are a hint that such tools are installed. Speedscale has recipes for coexisting with many of them; ask support.
 

--- a/docs/guides/production-readiness.md
+++ b/docs/guides/production-readiness.md
@@ -3,13 +3,13 @@ description: "Prepare a Speedscale eBPF traffic capture deployment for a safe pr
 sidebar_position: 20
 ---
 
-# Production readiness
+# Production Readiness
 
 Use the Speedscale eBPF collector for new Kubernetes production deployments. It observes traffic from each node without injecting a proxy into application pods or adding a network hop. Review the [eBPF system requirements](/reference/ebpf-traffic-collection#system-requirements) and [workload impact](/reference/ebpf-traffic-collection/workload-impact) before rollout.
 
 Use [sidecar capture](/getting-started/installation/sidecar/install) only for an existing deployment or a workload that does not meet the eBPF requirements.
 
-## Preparation checklist
+## Preparation Checklist
 
 - [ ] Confirm the target clusters, namespaces, and workloads.
 - [ ] Confirm that cluster nodes meet the eBPF requirements.
@@ -57,7 +57,7 @@ The Operator can read Kubernetes secrets for transforms such as JWT resigning. U
 
 Use [traffic filters](/guides/creating-filters) to exclude health checks, monitoring traffic, large payloads, and out-of-scope services before data is sent to Speedscale Cloud. Start from the `standard` filter and add environment-specific rules. Filtering is also the primary control for limiting ingest volume and network egress.
 
-## Deployment checklist
+## Deployment Checklist
 
 - [ ] Install the Operator and enable eBPF.
 - [ ] Apply a narrow capture target.

--- a/docs/guides/replay/kube.md
+++ b/docs/guides/replay/kube.md
@@ -14,7 +14,31 @@ The Speedscale Kubernetes Operator **must** be installed.
 
 Once you have created a snapshot you can replay it at any time in your own environment.
 
-![Test environment with all components deployed](./test-architecture.png)
+```mermaid
+flowchart TB
+    subgraph speedscale["Speedscale"]
+        snapshot["Previously captured traffic"]
+        config["Test settings"]
+        analysis["Analysis engine"]
+        results["Test results"]
+        analysis --> results
+    end
+
+    subgraph cluster["Your Kubernetes cluster"]
+        operator["Speedscale Operator"]
+        generator["Load generator"]
+        sut["Service under test"]
+        responder["Responder<br/>mock dependencies"]
+        operator -->|"captured traffic for replay"| generator
+        operator -->|"mock data and test config"| responder
+        generator --> sut
+        sut --> responder
+    end
+
+    snapshot --> operator
+    config --> operator
+    operator --> analysis
+```
 
 When you replay these are the key ingredients that you will use:
 
@@ -65,4 +89,3 @@ If this is the first time you are running a replay, you should start with the
 doesn't the report will give you an idea of how to configuration the data
 transformation. For more information about test configs see the
 [docs](../../reference/configuration/README.md).
-

--- a/docs/guides/tls.md
+++ b/docs/guides/tls.md
@@ -1,16 +1,14 @@
 ---
-title: Enabling TLS
-description: Learn how to secure your applications with TLS by implementing best practices and configurations outlined in Speedscale's comprehensive guide. This documentation provides essential steps to enhance communication security and ensure data integrity for your services.
+title: Capture TLS Traffic
+description: Capture TLS traffic in Kubernetes with the Speedscale eBPF collector, without adding certificates or configuring a proxy.
 sidebar_position: 7
 ---
 
 ## Prerequisites
-1. [The Operator is installed](../getting-started/quick-start.md).
-2. [A sidecar has been installed and traffic is being captured](/getting-started/installation/sidecar/install)
 
-:::warning Sidecar capture is deprecated
-This guide documents TLS configuration for existing sidecar deployments. For new Kubernetes installations, use the [eBPF collector](/reference/ebpf-traffic-collection), which captures supported TLS traffic without certificate or proxy configuration.
-:::
+1. [Install the Operator](../getting-started/quick-start.md).
+2. [Enable the eBPF collector](/reference/ebpf-traffic-collection#installation) and target your workload.
+3. Confirm that your language and TLS library are listed under [TLS Traffic Visibility](/reference/ebpf-traffic-collection#tls-traffic-visibility).
 
 ## Our app
 For this guide, we are using an app called `bq-app` that has an endpoint `/name/{state}` and makes calls out to Google's BigQuery on every inbound request.
@@ -19,27 +17,36 @@ For this guide, we are using an app called `bq-app` that has an endpoint `/name/
 
 ![Traffic](./tls/unrecognized.png)
 
-In the traffic viewer for our service, we can see individual requests and their headers, bodies, etc. However for a subset of the traffic captured, we see that it is marked as TLS. We know that this traffic is our outbound calls to Google BigQuery and we want to be able to inspect these requests as well. In order to capture and decode this traffic we need to enable TLS traffic capture.
+In the traffic viewer for our service, we can see individual requests and their headers and bodies. If a request is marked as TLS, Speedscale observed the connection but could not read the plaintext payload.
 
-## Enable TLS
+## Enable TLS capture
 
-We add the `tls-out` setting to our deployment via `kubectl edit deploy/{deployment_name}`. The `inject` setting was already present when we started capturing data in the first place.
+The eBPF collector reads plaintext at supported TLS library boundaries. It does not require a Speedscale certificate, a proxy, or the `sidecar.speedscale.com/tls-out` annotation.
 
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    sidecar.speedscale.com/inject: "true"
-    sidecar.speedscale.com/tls-out: "true"
+Enable capture for the deployment:
+
+```bash
+kubectl annotate deployment bq-app -n YOUR_NAMESPACE \
+  capture.speedscale.com/enabled="true" --overwrite
 ```
 
-:::danger
-TLS configuration depends heavily on the programming language your app uses. See [how to configure your app](/getting-started/installation/sidecar/tls/).
-:::
+Restart long-lived workloads after enabling capture so the collector sees new TLS connections from the beginning:
 
-This will change the sidecar settings on the deployment and cycle the pods to apply them.
+```bash
+kubectl rollout restart deployment bq-app -n YOUR_NAMESPACE
+```
 
 ![Decoded](./tls/decoded.png)
 
-Now we can see that the previously opaque requests with an IP address and TLS tech are now being successfully captured by Speedscale. We can see that our app makes 3 requests to BigQuery on every inbound request. On further inspection, we can actually see that it makes 1 POST for the query itself and 2 GET requests to paginate through the results. Previously we would have to inspect the source code of the Google SDK we are using to figure out its paging behavior but now we can observe all the requests it's making through Speedscale.
+The previously opaque requests are now decoded. In this example, the application makes one POST request for the BigQuery query and two GET requests to paginate through the results.
+
+## If traffic remains encrypted
+
+Check the collector requirements before changing your application:
+
+- Go applications require Go 1.18 or newer and an unstripped binary built without `-ldflags="-s"`.
+- OpenSSL capture requires OpenSSL 3.x. BoringSSL, LibreSSL, and older OpenSSL releases are not supported by the eBPF TLS probes.
+- Java applications use the Speedscale JVMTI agent, which the Operator manages with the eBPF collector.
+- Connections established before the probes attach can remain opaque until the application opens a new connection.
+
+See [eBPF limitations](/reference/ebpf-traffic-collection#limitations) for the complete list. Existing sidecar deployments can continue to use the legacy [sidecar TLS configuration](/getting-started/installation/sidecar/tls/).

--- a/docs/guides/tls.md
+++ b/docs/guides/tls.md
@@ -30,6 +30,15 @@ kubectl annotate deployment bq-app -n YOUR_NAMESPACE \
   capture.speedscale.com/enabled="true" --overwrite
 ```
 
+Java workloads also require the Operator-managed JVMTI agent. Enable it before restarting the workload:
+
+```bash
+kubectl annotate deployment bq-app -n YOUR_NAMESPACE \
+  capture.speedscale.com/java-agent="true" --overwrite
+```
+
+The Java agent changes the pod template so it can load inside the JVM. See [Java eBPF capture](/reference/languages/java#ebpf-java-agent) for details.
+
 Restart long-lived workloads after enabling capture so the collector sees new TLS connections from the beginning:
 
 ```bash

--- a/docs/guides/transformation/overview.md
+++ b/docs/guides/transformation/overview.md
@@ -98,7 +98,7 @@ How can the request and response both use the same transforms? Because each tran
 
 A complete set of traffic transformation configuration is stored as a Traffic Transform Template (TTT). You can view and edit these in the main [UI](https://app.speedscale.com/trafficTransforms). Although TTT's can be edited graphically, they are stored as JSONs for easy portability.
 
-## Traffic transform templates
+## Traffic Transform Templates
 
 Traffic Transform Templates allow you to save transform configurations from one snapshot and reuse them in subsequent snapshots. This enables you to:
 

--- a/docs/guides/transformation/overview.md
+++ b/docs/guides/transformation/overview.md
@@ -55,7 +55,18 @@ Transforms also have a data cache where **variables** can be stored. Variables f
 
 Last, the transformed data is re-inserted into the RRPair in exactly the same location. Each transform runs in reverse order to re-encode the new **token** and place it back in its correct place.
 
-![Concrete example of two transforms](./overview/diagram_with_data.png)
+```mermaid
+flowchart LR
+    subgraph rrpair["RRPair"]
+        header["Record-Timestamp:<br/>Sat, 20 Nov 2019 07:16:26 GMT"]
+        body["order-id: 52-3059"]
+    end
+
+    header --> extractHeader["Extract header"] --> dateOffset["Date offset"]
+    dateOffset --> extractHeader --> header
+    body --> extractJson["Extract JSON"] --> insertText["Insert text"]
+    insertText --> extractJson --> body
+```
 
 ## Where to Transform Traffic
 
@@ -87,7 +98,7 @@ How can the request and response both use the same transforms? Because each tran
 
 A complete set of traffic transformation configuration is stored as a Traffic Transform Template (TTT). You can view and edit these in the main [UI](https://app.speedscale.com/trafficTransforms). Although TTT's can be edited graphically, they are stored as JSONs for easy portability.
 
-## Traffic Transform Templates
+## Traffic transform templates
 
 Traffic Transform Templates allow you to save transform configurations from one snapshot and reuse them in subsequent snapshots. This enables you to:
 
@@ -107,4 +118,3 @@ Templates are particularly useful for:
 - APIs with consistent authentication patterns
 - Services that require similar data sanitization
 - Test scenarios that need identical transform chains across multiple snapshots
-

--- a/docs/proxymock/guides/cicd.md
+++ b/docs/proxymock/guides/cicd.md
@@ -15,7 +15,16 @@ deployment with confidence.
 Run **proxymock** after your build and unit tests, but before deploying to
 production.
 
-![CI Pipeline](./cicd/cicd-flow.png)
+```mermaid
+flowchart LR
+    code["Code"] --> commit["Commit"]
+    commit --> build["Build"]
+    build --> unit["Unit tests"]
+    unit --> replay["proxymock integration tests"]
+    replay --> review["Review"]
+    review --> staging["Staging"]
+    staging --> production["Production"]
+```
 
 Adding anything to your CI/CD pipeline generally involves the same 3 steps:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,8 +34,6 @@ flowchart LR
     outbound --> postgres["Postgres"]
 ```
 
-The Speedscale components are in orange and your components are in green.
-
 The curl HTTP client is used to make a request directly to the Speedscale proxy
 which forwards that request to your app, capturing the inbound request. Your
 app handles the inbound request and makes a database query to Postgres.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -136,7 +136,7 @@ window and your app should receive all requests from the snapshot.
 With `--daemon` flag, You can run generator and responder as a background process.  
 :::
 
-## Create local mocks
+## Create Local Mocks
 
 Local mocks are just another replay with no generator.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,7 +26,13 @@ Speedscale [proxy](../reference/glossary.md#proxy).
 
 The traffic flow will look should look something like this:
 
-![traffic-flow](./cli/capture-flow.png)
+```mermaid
+flowchart LR
+    curl["curl"] --> inbound["Speedscale proxy<br/>inbound"]
+    inbound --> app["Your app"]
+    app --> outbound["Speedscale proxy<br/>outbound"]
+    outbound --> postgres["Postgres"]
+```
 
 The Speedscale components are in orange and your components are in green.
 
@@ -75,7 +81,13 @@ https://app.speedscale.com.
 Once you have captured traffic you can
 [create a snapshot](../guides/creating-a-snapshot.md) and replay it against your app.
 
-![replay-flow](./cli/replay-flow.png)
+```mermaid
+flowchart LR
+    snapshot["Snapshot traffic"] -.-> generator["Generator"]
+    snapshot -.-> responder["Responder"]
+    generator --> app["Your app"]
+    app --> responder
+```
 
 The captured traffic is loaded into Speedscale components before the replay
 starts. The [generator](../reference/glossary.md#generator) makes requests to
@@ -124,7 +136,7 @@ window and your app should receive all requests from the snapshot.
 With `--daemon` flag, You can run generator and responder as a background process.  
 :::
 
-## Create Local Mocks
+## Create local mocks
 
 Local mocks are just another replay with no generator.
 

--- a/docs/reference/pricing-faq.md
+++ b/docs/reference/pricing-faq.md
@@ -64,7 +64,7 @@ Set the value back to `"true"` when the recording window begins. Annotation-base
 
 Use your deployment automation or a CronJob to enable eBPF capture only during performance tests, CI/CD workflows, or planned recording windows. See [eBPF annotation-based capture](/reference/ebpf-traffic-collection#enabling-via-annotation).
 
-If remote control is enabled, the built-in [scheduler](https://app.speedscale.com/schedules) can start and stop recording windows for you instead. See [schedules](/concepts/schedules) for the available actions.
+For legacy sidecar capture, the built-in [scheduler](https://app.speedscale.com/schedules) can start and stop recording windows when remote control is enabled. The scheduler does not change eBPF capture targets or annotations. See [schedules](/concepts/schedules) for the available actions.
 
 ### 🎯 5. Scope deployments
 Use eBPF capture targets to select only the namespaces and workloads with active testing or observability needs. Avoid cluster-wide capture unless it is required.

--- a/docs/reference/pricing-faq.md
+++ b/docs/reference/pricing-faq.md
@@ -9,8 +9,6 @@ import PricingDashboard from './pricing-faq/pricing-dashboard.png'
 
 Speedscale's pricing is based on the amount of data ingested, measured in gigabytes (GB). Below are answers to common questions about how billing works, how to avoid surprises, and how to optimize your usage.
 
----
-
 ## 💡 How does Speedscale’s usage-based pricing work?
 
 Speedscale charges based on the total amount of data ingested to Speedscale Cloud, measured in GB per month. You can view your usage within Usage section of the [Speedscale UI](https://app.speedscale.com/tenant#tenant-tab-usage).
@@ -38,7 +36,7 @@ Speedscale provides various usage metrics for visibility, but only data ingest i
 
 ## ⚠️ What are some common causes of unexpected overages?
 
-1. **High-traffic services**: If you deploy the sidecar to high-throughput services without filtering, usage can spike quickly.  
+1. **High-traffic services**: If you capture high-throughput services without filtering, usage can spike quickly.
 1. **Background or noisy traffic**: Health checks, polling endpoints, or verbose internal service calls can add significant overhead.  
 1. **Unfiltered ingress**: Without filters, *all* incoming/outgoing traffic is captured by default, including irrelevant or duplicate traffic.  
 1. **Replays and load tests**: Running tests with high concurrency can multiply the amount of data ingested. Use Low Data Mode when you run performance tests.
@@ -49,29 +47,32 @@ Speedscale provides various usage metrics for visibility, but only data ingest i
 Here are several strategies to avoid surprises:
 
 ### ✅ 1. Use traffic filters
-Apply [traffic filters](/guides/creating-filters) to only capture data from specific endpoints, headers, or service patterns. This reduces noise and focuses ingest on meaningful interactions. The most common "noisy" traffic patterns include heartbeats, monitoring systems and database keepalives. Common systems like Datadog and New Relic are filtered out in the default `standard` filter set (for example). To do that, check out the [ignore-src-ips](/getting-started/installation/sidecar/annotations#sidecarspeedscalecomignore-src-ips) and [ignore-src-hosts](/getting-started/installation/sidecar/annotations#sidecarspeedscalecomignore-src-hosts) annotations.
+Apply [traffic filters](/guides/creating-filters) to capture only the endpoints, headers, or service patterns that matter. This reduces noise and focuses ingest on useful interactions. Common noisy traffic includes health checks, monitoring systems, and database keepalives. The default `standard` filter set excludes common monitoring traffic such as Datadog and New Relic.
 
-### 🛑 2. Turn off the sidecar during idle periods
-You can disable the Speedscale sidecar dynamically via your deployment configuration or control plane. Use automation to stop ingesting traffic outside of business hours or test windows.
+### 🛑 2. Turn off capture during idle periods
 
-:::tip
-By default, Speedscale enables Remote Control which lets you turn the sidecar on and off manually, or using the scheduler. To turn on/off a sidecar, visit the main navigation -> Infrastructure -> Workloads -> (select namespace) -> inject (toggle on/off using the slider)
+Use the eBPF capture annotation to stop collecting from a workload outside business hours or test windows:
 
-![workload inject](./pricing-faq/workload-inject.png)
-:::
+```bash
+kubectl annotate deployment my-app -n my-namespace \
+  capture.speedscale.com/enabled="false" --overwrite
+```
 
-### ⚙️ 3. Enable sidecar only during recording windows
-Use Kubernetes lifecycle hooks or cronjobs to activate Speedscale only during performance testing, CI/CD workflows, or specific test events. Speedscale also provides an automated [scheduler](https://app.speedscale.com/schedules) if you have remote control enabled.
+Set the value back to `"true"` when the recording window begins. Annotation-based targeting requires `ebpf.enabled: true` in the Operator Helm values.
+
+### ⚙️ 3. Capture only during recording windows
+
+Use your deployment automation or a CronJob to enable eBPF capture only during performance tests, CI/CD workflows, or planned recording windows. See [eBPF annotation-based capture](/reference/ebpf-traffic-collection#enabling-via-annotation).
 
 ### 🎯 5. Scope deployments
-Limit sidecar injection to namespaces, clusters, or services with active testing or observability needs. Avoid deploying universally unless necessary.
+Use eBPF capture targets to select only the namespaces and workloads with active testing or observability needs. Avoid cluster-wide capture unless it is required.
 
 ## 🧪 Can I test while limiting ingest costs?
 
 Yes. Speedscale offers the ability to:
 
 - **Record once, replay many times**: Replays of previously recorded traffic do not count as new ingest, although the test artifacts will cause some minor ingest.
-- **Use local proxymock recordings**: Capture and replay traffic locally during development without involving the sidecar or ingesting data into the Speedscale cloud. Limits apply but this is a good option for quick local regressions.
+- **Use local proxymock recordings**: Capture and replay traffic locally during development without ingesting data into Speedscale Cloud. Limits apply, but this is a good option for quick local regressions.
 
 
 You can see current and historical usage by navigating to **Settings > Usage** in the Speedscale UI. Detailed breakdowns by service and namespace are available for the last seven days to help identify cost centers. Click on the main navigation -> Services for a list of services that have reported traffic in the last seven days.
@@ -117,9 +118,9 @@ Absolutely. Here are a few customer-tested techniques:
 
 | Practice                     | Description                                                                  |
 |-----------------------------|------------------------------------------------------------------------------|
-| Inject sidecars selectively | Use namespace or label-based injection controls                              |
+| Target workloads selectively | Use namespace and pod selectors in the eBPF capture configuration          |
 | Add smart filters           | Only capture what’s needed for test coverage or debugging                    |
-| Use test scheduling         | Automate sidecar activation only during CI/CD jobs or staging rollouts       |
+| Use test scheduling         | Enable capture only during CI/CD jobs or planned recording windows           |
 | Monitor billing data weekly | Watch for anomalous spikes before they turn into bill surprises              |
 | Reuse traffic recordings    | Reduce ingest by replaying stored traffic scenarios instead of re-recording  |
 

--- a/docs/reference/pricing-faq.md
+++ b/docs/reference/pricing-faq.md
@@ -64,6 +64,8 @@ Set the value back to `"true"` when the recording window begins. Annotation-base
 
 Use your deployment automation or a CronJob to enable eBPF capture only during performance tests, CI/CD workflows, or planned recording windows. See [eBPF annotation-based capture](/reference/ebpf-traffic-collection#enabling-via-annotation).
 
+If remote control is enabled, the built-in [scheduler](https://app.speedscale.com/schedules) can start and stop recording windows for you instead. See [schedules](/concepts/schedules) for the available actions.
+
 ### 🎯 5. Scope deployments
 Use eBPF capture targets to select only the namespaces and workloads with active testing or observability needs. Avoid cluster-wide capture unless it is required.
 

--- a/docs/reference/replay_data_model.md
+++ b/docs/reference/replay_data_model.md
@@ -5,7 +5,34 @@ sidebar_position: 6
 
 # Replay Data Model
 
-![Replay Data Model](./replay_data_model/replay_data_model.png)
+```mermaid
+flowchart TB
+    subgraph inputs["Inputs"]
+        direction TB
+        raw["Raw request/response pairs"]
+        transformTemplate["Traffic transform template"]
+    end
+
+    subgraph snapshot["Snapshot"]
+        direction TB
+        transforms["Traffic transforms"]
+        tokens["Discovered tokens"]
+        rrpairs["Raw request/response pairs"]
+        requests["Client requests"]
+        mocks["Mock responses"]
+    end
+
+    subgraph report["Report"]
+        direction TB
+        testConfig["Test config"]
+        results["Requests, responses, assertions, and metrics"]
+    end
+
+    raw --> snapshot
+    transformTemplate --> snapshot
+    snapshot --> report
+    testTemplate["Test config template"] --> report
+```
 
 ### What happens when a snapshot is created?
 

--- a/docs/reference/technology-support.md
+++ b/docs/reference/technology-support.md
@@ -14,12 +14,12 @@ Speedscale replays involve three distinct steps that are supported separately: *
 | Technology | Type     | Support | Notes                          |
 | ---------- | -------- | ------- | ------------------------------ |
 | .NET       | Language | Full    | See [.NET](/reference/languages/dotnet#proxymock) and [TLS](/reference/languages/dotnet#tls-trust) |
-| C++        | Language | Full    | See [TLS capture](/guides/tls/) |
+| C++        | Language | Full    | See [sidecar TLS](/getting-started/installation/sidecar/tls/) |
 | Go         | Language | Full    | See [Go](/reference/languages/golang#proxymock) and [TLS](/reference/languages/golang#tls-trust) |
 | Java       | Language | Full    | See [Java](/reference/languages/java#proxymock) and [TLS](/reference/languages/java#tls-trust) |
 | Node.js    | Language | Full    | See [Node.js](/reference/languages/nodejs#proxymock) and [TLS](/reference/languages/nodejs#tls-trust) |
 | Python     | Language | Full    | See [Python](/reference/languages/python#proxymock) and [TLS](/reference/languages/python#tls-trust) |
-| Ruby       | Language | Full    | See [TLS capture](/guides/tls/) |
+| Ruby       | Language | Full    | See [sidecar TLS](/getting-started/installation/sidecar/tls/) |
 
 ### Supported Protocols
 
@@ -36,7 +36,7 @@ Speedscale replays involve three distinct steps that are supported separately: *
 | IMAP              | Protocol | Capture Only |                                                                                    |
 | JSON              | Protocol | Full         |                                                                                    |
 | Kafka             | Protocol | Full         | See [details](../guides/message-brokers/kafka.md)                     |
-| Mutual TLS (mTLS) | Protocol | Partial      | See [TLS capture](/guides/tls/)                                                                           |
+| Mutual TLS (mTLS) | Protocol | Partial      | See [sidecar mutual authentication](/getting-started/installation/sidecar/tls/#mutual-authentication-for-outbound-calls)                         |
 | Protobuf          | Protocol | Full         |                                                                                    |
 | RabbitMQ          | Protocol | Full         | See [details](../guides/message-brokers/rabbitmq.md)                              |
 | SOAP              | Protocol | Full         |                                                                                    |
@@ -109,7 +109,7 @@ Speedscale automatically detects and supports popular LLM (Large Language Model)
 | Perplexity       | LLM  | Full    | Auto-detected via `api.perplexity.ai`                   |
 
 :::tip
-LLM provider traffic is standard HTTP/HTTPS — no special configuration is required. Speedscale will automatically detect and label LLM API calls when traffic flows through the proxy. See the [LLM Simulation guide](../guides/mocking/llm-simulation.md) for how to use recorded LLM traffic as mocks in development, CI, and load testing.
+LLM provider traffic is standard HTTP/HTTPS. No special configuration is required. Speedscale automatically detects and labels LLM API calls when the traffic is captured. See the [LLM Simulation guide](../guides/mocking/llm-simulation.md) for how to use recorded LLM traffic as mocks in development, CI, and load testing.
 :::
 
 ### Environments <a href="#environments" id ="environments"></a>

--- a/docs/reference/technology-support.md
+++ b/docs/reference/technology-support.md
@@ -14,12 +14,12 @@ Speedscale replays involve three distinct steps that are supported separately: *
 | Technology | Type     | Support | Notes                          |
 | ---------- | -------- | ------- | ------------------------------ |
 | .NET       | Language | Full    | See [.NET](/reference/languages/dotnet#proxymock) and [TLS](/reference/languages/dotnet#tls-trust) |
-| C++        | Language | Full    | See [TLS](/getting-started/installation/sidecar/tls/) |
+| C++        | Language | Full    | See [TLS capture](/guides/tls/) |
 | Go         | Language | Full    | See [Go](/reference/languages/golang#proxymock) and [TLS](/reference/languages/golang#tls-trust) |
 | Java       | Language | Full    | See [Java](/reference/languages/java#proxymock) and [TLS](/reference/languages/java#tls-trust) |
 | Node.js    | Language | Full    | See [Node.js](/reference/languages/nodejs#proxymock) and [TLS](/reference/languages/nodejs#tls-trust) |
 | Python     | Language | Full    | See [Python](/reference/languages/python#proxymock) and [TLS](/reference/languages/python#tls-trust) |
-| Ruby       | Language | Full    | See [TLS](/getting-started/installation/sidecar/tls/) |
+| Ruby       | Language | Full    | See [TLS capture](/guides/tls/) |
 
 ### Supported Protocols
 
@@ -32,11 +32,11 @@ Speedscale replays involve three distinct steps that are supported separately: *
 | gRPC              | Protocol | Full         | See [details](/guides/capture/bodies#grpc)                                             |
 | HTTP 1.1          | Protocol | Full         |                                                                                    |
 | HTTP 2.0          | Protocol | Full         |                                                                                    |
-| HTTP/S TLS        | Protocol | Full         | See [TLS](/getting-started/installation/sidecar/tls/)                                                     |
+| HTTP/S TLS        | Protocol | Full         | See [TLS capture](/guides/tls/)                                                                          |
 | IMAP              | Protocol | Capture Only |                                                                                    |
 | JSON              | Protocol | Full         |                                                                                    |
 | Kafka             | Protocol | Full         | See [details](../guides/message-brokers/kafka.md)                     |
-| Mutual TLS (mTLS) | Protocol | Partial      | See [TLS](/getting-started/installation/sidecar/tls/)                                                     |
+| Mutual TLS (mTLS) | Protocol | Partial      | See [TLS capture](/guides/tls/)                                                                           |
 | Protobuf          | Protocol | Full         |                                                                                    |
 | RabbitMQ          | Protocol | Full         | See [details](../guides/message-brokers/rabbitmq.md)                              |
 | SOAP              | Protocol | Full         |                                                                                    |


### PR DESCRIPTION
# Problem

The active documentation reflected an older installation model. Several guides taught sidecar capture first, conceptual diagrams were maintained as image assets rather than Mermaid, and the pricing and production guidance assumed sidecar injection was the way to control what gets recorded. The product defaults to eBPF capture in Kubernetes.

# Solution

Make eBPF the default capture method across the active TLS, production-readiness, Argo Rollouts, capture, integration, and pricing guidance. Sidecar instructions stay where they are platform-specific or explicitly marked as a legacy fallback, so existing sidecar users keep working links.

Replace 13 referenced static conceptual diagrams with Mermaid, including the main Getting Started architecture diagram.

The GKE Autopilot rewrite that was originally part of this PR has been split out to #730 and is on hold. It dropped chart-version pinning on the grounds that the allowlist is version-independent, which is only true of the partner allowlist Google merged on 2026-08-07 but has not yet published. Customers are still on the customer-owned `workload-allowlist.yaml`, which pins image digests to a chart version, so unpinning would get nettap pods rejected by Warden.

Restored in this PR, after review found it dropped with no home elsewhere in the docs:

- The `namespaceSelector` RBAC behavior in production-readiness, covering `ClusterRole` versus per-namespace `Role`. `reference/helm.md` documents the value but not what it does to permissions, and this is a standard security-review question.
- The SaaS agreement prerequisite for production support.
- The service mesh and cluster security tooling checks in the preparation checklist.
- The Argo Rollouts sidecar removal steps, so existing sidecar-on-rollout users still have uninstall instructions.
- The scheduler as a legacy sidecar option for recording windows in the pricing FAQ.

Follow-up review also corrected the Java JVMTI annotation and Argo rollout behavior, scoped the Istio production link to eBPF-relevant networking requirements, restored sidecar-specific C++/Ruby and mTLS links, made LLM detection wording capture-mode neutral, and removed two stale diagram-color captions.

# Impact

New Kubernetes users are directed to eBPF capture without unnecessary proxy or certificate configuration. Existing sidecar users retain links to the legacy installation and TLS guidance where needed.

Roughly ten diagram PNGs become unreferenced and are left in the repo for a separate cleanup.

## Checklist

- [x] Production Docusaurus build passes with no broken-link or broken-anchor warnings
- [x] Every anchor into the eBPF reference verified to resolve
- [x] Annotation names and Helm value shapes verified against `reference/ebpf-traffic-collection` and `reference/helm.md`
- [x] Browser render check for every converted Mermaid diagram
- [x] `check-ai-tells.sh` on every changed documentation file
- [x] `git diff --check` clean