### PR TITLE
Add redirects for /dlp/* and triggers pages still 404ing

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -827,6 +827,30 @@ const config = {
             from: "/mocks/triggers/",
             to: "/guides/mocking/mocks/",
           },
+          // Still 404ing in Google Search Console.
+          // The /dlp/* tree moved under /guides/dlp/; only the section-level
+          // paths were redirected, not the individual pages Google indexed.
+          { from: "/dlp/introduction/", to: "/guides/dlp/introduction/" },
+          { from: "/dlp/applying-rules/", to: "/guides/dlp/applying-rules/" },
+          { from: "/dlp/best-practices/", to: "/guides/dlp/best-practices/" },
+          { from: "/dlp/cli-reference/", to: "/guides/dlp/cli-reference/" },
+          { from: "/dlp/creating-rules/", to: "/guides/dlp/creating-rules/" },
+          { from: "/dlp/discovering-pii/", to: "/guides/dlp/discovering-pii/" },
+          { from: "/dlp/recommendations/", to: "/guides/dlp/recommendations/" },
+          {
+            from: "/dlp/test-data-generation/",
+            to: "/guides/dlp/test-data-generation/",
+          },
+          { from: "/dlp/troubleshooting/", to: "/guides/dlp/troubleshooting/" },
+          // Triggers folded into the mocks guide, matching /mocks/triggers/ above.
+          { from: "/concepts/triggers/", to: "/guides/mocking/mocks/" },
+          { from: "/transform/triggers/", to: "/guides/mocking/mocks/" },
+          { from: "/guides/mocking/triggers/", to: "/guides/mocking/mocks/" },
+          {
+            from: "/transform/extractors/http_res_trailer/",
+            to: "/guides/transformation/extractors/http_res_trailer/",
+          },
+          { from: "/guides/getting-started/", to: "/" },
           {
             from: "/observe/bodies/",
             to: "/guides/capture/bodies/",


### PR DESCRIPTION
## Problem

The DLP docs moved from `/dlp/*` to `/guides/dlp/*`. The redirect map covers the section-level paths (`/dlp/api-reference/`, `/dlp/examples/`, `/dlp/glossary/`, `/dlp/appendix/`, `/dlp/security-compliance/`) but not the individual pages Google actually indexed, so nine of them still return 404. Confirmed live: `/dlp/introduction/` 404s while `/guides/dlp/introduction/` returns 200.

These account for most of the docs URLs sitting in the "Not found (404)" bucket in Search Console.

## Solution

Adds 14 redirects:

- The nine `/dlp/<page>/` paths to their `/guides/dlp/<page>/` equivalents
- `/concepts/triggers/`, `/transform/triggers/`, `/guides/mocking/triggers/` to `/guides/mocking/mocks/`, matching the existing `/mocks/triggers/` entry
- `/transform/extractors/http_res_trailer/` to `/guides/transformation/extractors/http_res_trailer/`
- `/guides/getting-started/` to `/`, matching the existing `/getting-started/introduction/` entry

## Test plan

- `yarn build` succeeds. `@docusaurus/plugin-client-redirects` fails the build on a `from` that collides with a real route, so a clean build is the collision check.
- All 14 redirect pages generate in `build/` and point at the intended target.
- Every target exists in the build output and returns 200 on the live site.
- No duplicate `from` entries across all 390 redirects in the config.

`/auth-callback` also appears in the 404 report but is an OAuth callback path, not a doc — left alone deliberately.