### PR TITLE
Drop Autopilot chart-version pinning once the partner allowlist publishes

### DIFF
--- a/docs/getting-started/installation/install/gke-autopilot.md
+++ b/docs/getting-started/installation/install/gke-autopilot.md
@@ -1,6 +1,6 @@
 ---
 title: GKE Autopilot
-description: The complete guide to running Speedscale on GKE Autopilot. Covers both capture paths — eBPF via a customer-owned WorkloadAllowlist (support request, org policy, AllowlistSynchronizer) and sidecar dual proxy mode — plus the Autopilot-specific Helm values required to pass Warden admission.
+description: The complete guide to running Speedscale on GKE Autopilot. Covers eBPF capture with a customer-owned WorkloadAllowlist and the deprecated sidecar fallback, plus the Helm values required to pass Warden admission.
 sidebar_position: 12
 ---
 
@@ -14,9 +14,9 @@ This workflow is currently in preview status. Please provide feedback in our [Sl
 
 ## Capture Options on Autopilot
 
-Autopilot's restrictions affect how Speedscale captures traffic. There are two supported approaches — pick one:
+Autopilot's restrictions affect how Speedscale captures traffic. There are two supported approaches. Pick one:
 
-- **eBPF capture** (the main path on this page). A privileged `nettap` DaemonSet captures traffic for whole namespaces. It needs a **customer-owned [WorkloadAllowlist](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-privileged-allowlists)** to admit the privileged pods, which requires a one-time Google Cloud eligibility request (about one week of lead time). Best for broad, low-touch capture across many workloads. This path is needed until the Speedscale Autopilot partner allowlist is published globally.
+- **eBPF capture** (the main path on this page). A privileged `nettap` DaemonSet captures traffic for whole namespaces. It needs a **customer-owned [WorkloadAllowlist](https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-privileged-allowlists)** to admit the privileged pods, which requires a one-time Google Cloud eligibility request (about one week of lead time). The Speedscale allowlist is version-independent, so one file supports operator upgrades without a matching allowlist for every release.
 - **[Sidecar capture (dual proxy mode)](#sidecar-capture-dual-proxy-mode)** (deprecated). A per-workload sidecar proxy retained for existing deployments and clusters that cannot obtain a WorkloadAllowlist. Autopilot forbids the sidecar's transparent proxy, so it must run in `dual` proxy mode and the app's outbound traffic must be pointed at it.
 
 The rest of this page walks through the recommended eBPF path. Jump to [Sidecar Capture](#sidecar-capture-dual-proxy-mode) only if you need the deprecated fallback.
@@ -28,11 +28,11 @@ The rest of this page walks through the recommended eBPF path. Jump to [Sidecar 
 - Permission to set project org policies.
 - `gcloud`, `kubectl`, and `helm`.
 - A Speedscale API key.
-- Two files from Speedscale support, matched to a specific operator chart version:
+- Two version-independent files from Speedscale support:
   - `workload-allowlist.yaml`
   - `allowlist-synchronizer.yaml`
 
-Contact [Speedscale support](https://slack.speedscale.com) to get the allowlist files. The `workload-allowlist.yaml` pins exact container image SHA-256 digests, so it is tied to one operator chart version. Install that exact chart version (see [Step 6](#6-install-speedscale-with-ebpf)).
+Contact [Speedscale support](https://slack.speedscale.com) to get the allowlist files. Keep these files in version control with your cluster configuration. You do not need a new `workload-allowlist.yaml` when upgrading the operator.
 
 Set these variables for the commands below:
 
@@ -42,7 +42,6 @@ export REGION="us-central1"
 export CLUSTER_NAME="YOUR_CLUSTER_NAME"
 export BUCKET_NAME="${PROJECT_ID}-speedscale-autopilot-allowlists"
 export SPEEDSCALE_API_KEY="YOUR_SPEEDSCALE_API_KEY"
-export CHART_VERSION="VERSION_MATCHED_TO_YOUR_ALLOWLIST"
 ```
 
 Enable the required APIs:
@@ -196,16 +195,11 @@ If the synchronizer is not Ready, inspect `status.conditions[*].message` and `st
 
 Add the Speedscale Helm repo and [install the operator](./kubernetes-operator.md) with eBPF enabled.
 
-:::caution Pin the chart version
-Install the chart version that matches your `workload-allowlist.yaml`. The allowlist pins exact image SHA-256 digests; a different chart version pulls different `nettap`/`goproxy` images whose digests will not match, and Warden will reject the nettap pods. To move to a newer version, get a re-pinned `workload-allowlist.yaml` from Speedscale first.
-:::
-
 ```bash
 helm repo add speedscale https://speedscale.github.io/operator-helm/
 helm repo update
 
 helm upgrade --install speedscale-operator speedscale/speedscale-operator \
-  --version "${CHART_VERSION}" \
   --namespace speedscale --create-namespace \
   --set apiKey="${SPEEDSCALE_API_KEY}" \
   --set clusterName="${CLUSTER_NAME}" \
@@ -239,32 +233,26 @@ export APP_NAMESPACE="YOUR_APP_NAMESPACE"
 export APP_NAME="YOUR_APP_LABEL"
 
 helm upgrade speedscale-operator speedscale/speedscale-operator \
-  --version "${CHART_VERSION}" \
   --namespace speedscale --reuse-values \
   --set "ebpf.configuration.capture.targets[0].name=${APP_NAME}" \
   --set "ebpf.configuration.capture.targets[0].namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name=${APP_NAMESPACE}" \
   --set "ebpf.configuration.capture.targets[0].podSelector.matchLabels.app=${APP_NAME}"
 ```
 
-`--reuse-values` preserves your install values but not the chart version, so pin `--version` again here. Generate traffic against the workload, then confirm it appears in Speedscale.
+Generate traffic against the workload, then confirm it appears in Speedscale.
 
 ## Updating Speedscale Versions
 
-The WorkloadAllowlist pins container image digests, so it must be updated in lockstep with the chart. When Speedscale provides an updated `workload-allowlist.yaml` (and its matching chart version), upload it to the same bucket path:
+The Speedscale WorkloadAllowlist matches the approved workload shape and image repositories rather than a specific operator version. Upgrade the operator normally with Helm; the existing `workload-allowlist.yaml` and `AllowlistSynchronizer` continue to apply.
 
 ```bash
-gcloud storage cp workload-allowlist.yaml \
-  "gs://${BUCKET_NAME}/nettap/workload-allowlist.yaml"
+helm repo update
+helm upgrade speedscale-operator speedscale/speedscale-operator \
+  --namespace speedscale \
+  --reuse-values
 ```
 
-Force a sync:
-
-```bash
-kubectl annotate allowlistsynchronizer speedscale-nettap-sync \
-  force-sync="$(date +%s)" --overwrite
-```
-
-Then upgrade the chart to the matching `--version`.
+If Speedscale changes the privileged workload shape, Speedscale support will provide an updated allowlist. Upload it to the existing bucket path and the `AllowlistSynchronizer` will install it automatically.
 
 ## Java Agent Notes
 
@@ -281,7 +269,6 @@ On Autopilot, the operator's Java Agent init container can be rejected if the in
 | AllowlistSynchronizer not Ready | Bucket IAM, path mismatch, invalid YAML, or incompatible GKE version | Confirm `container-engine-robot` has `objectViewer` and `bucketViewer`, then inspect synchronizer status |
 | Nettap pods rejected by Warden | Resource requests and limits do not match | Reinstall with matching requests and limits |
 | Replay init containers rejected by Warden | Missing `ephemeral-storage` values | Reinstall with the `sidecar.resources.*.ephemeral-storage=100Mi` values |
-| Nettap image digest mismatch after a chart upgrade | Installed chart version does not match the allowlist | Install the chart `--version` that matches your `workload-allowlist.yaml`, or upload the updated allowlist from Speedscale |
 | Forwarder crashes with `FATAL: failed to get filter rule` | `filterRule=none` in the configmap | Patch it: `kubectl patch cm speedscale-forwarder -n speedscale --type merge -p '{"data":{"SPEEDSCALE_FILTER_RULE":"standard"}}'` |
 
 ## Sidecar Capture (Dual Proxy Mode)
@@ -334,7 +321,7 @@ sidecar.speedscale.com/ephemeral-storage-limit: 100Mi
 
 ### Configure the application
 
-Dual mode does not reconfigure your runtime — the app must route outbound traffic to the sidecar's forward proxy on `127.0.0.1:4140` (unless you changed `proxy-out-port`):
+Dual mode does not reconfigure your runtime. The app must route outbound traffic to the sidecar's forward proxy on `127.0.0.1:4140` unless you changed `proxy-out-port`:
 
 - **Java:** add `-Dhttp.proxyHost`, `-Dhttp.proxyPort`, `-Dhttps.proxyHost`, and `-Dhttps.proxyPort` via `JAVA_TOOL_OPTIONS`. If you enable `tls-out`, add the truststore flags from the [Java reference](/reference/languages/java.md).
 - **Runtimes that honor proxy env vars:** set `HTTP_PROXY` and `HTTPS_PROXY` to `http://127.0.0.1:4140`.


### PR DESCRIPTION
# Problem

The GKE Autopilot guide tells customers to pin the operator chart to a version matching their `workload-allowlist.yaml`, because that file pins exact nettap and goproxy image SHA-256 digests. That constraint goes away with the partner allowlist, which uses a version-agnostic name and no digest pinning.

Split out of #727, where this change was bundled with the site-wide eBPF-first rewrite. It is held separately because it cannot land yet.

# Solution

Remove `CHART_VERSION`, the `--version` pins on both the install and target commands, the "Pin the chart version" caution, and the image-digest-mismatch troubleshooting row. Describe the allowlist as version-independent and the upgrade path as a normal `helm upgrade`.

**Do not merge until Google publishes `gke://Speedscale/nettap/*`.** The partner allowlist merged into Google's Gerrit repo on 2026-08-07 (change 8140, patchset 10) and does drop image-digest pinning. Publication is still pending on Google's side, with no confirmed ETA. Until it lands, customers are on the customer-owned allowlist path, whose `workload-allowlist.yaml` ends in `containerImageDigests` tied to one chart version. Merging early would produce install instructions where Warden rejects the nettap pods, with the troubleshooting row that explains it deleted. Home Depot and Ascension are on that interim path today.

When the partner allowlist publishes, this branch should be revisited rather than merged blind: the page will likely also need the `gke://` reference path documented, and the customer-owned bucket and `AllowlistSynchronizer` steps may become a fallback section rather than the main path.

## Checklist

- [x] Production Docusaurus build passes with no broken-link or broken-anchor warnings
- [x] `git diff --check` clean
- [x] Draft until the upstream dependency clears