### PR TITLE
Scope replay waits in external driver docs

### DIFF
--- a/docs/guides/integrations/cicd/cicd.md
+++ b/docs/guides/integrations/cicd/cicd.md
@@ -395,7 +395,7 @@ The pipeline order is:
 1. Run the test driver against the service under test.
 1. Cancel the replay, including when the driver fails or the job is interrupted.
 
-Use Speedscale v2.5.789 or newer in the cluster and `speedctl` v2.5.789 or newer in CI. Older operators do not publish the `MocksReady` condition consumed by the CLI. Configure the responder with `passthrough_mode: false` when the test must fail instead of reaching a live dependency. The [external driver demo](https://github.com/speedscale/demo/tree/master/scenarios/replay-sandwich) includes a complete test config and a reusable wrapper script.
+Use Speedscale v2.5.789 or newer in the cluster and `speedctl` v2.5.833 or newer in CI. Older operators do not publish the `MocksReady` condition consumed by the CLI. Older clients cannot scope the wait to the target cluster and namespace. Configure the responder with `passthrough_mode: false` when the test must fail instead of reaching a live dependency. The [external driver demo](https://github.com/speedscale/demo/tree/master/scenarios/replay-sandwich) includes a complete test config and a reusable wrapper script.
 
 ```bash
 #!/usr/bin/env bash
@@ -426,6 +426,8 @@ REPORT_ID=$(speedctl infra replay \
 
 speedctl wait replay "$REPORT_ID" \
   --for mocks-ready \
+  --cluster "$CLUSTER" \
+  --namespace "$NAMESPACE" \
   --timeout "$TIMEOUT" \
   --poll-interval 5s
 

--- a/docs/guides/replay/via-speedctl.md
+++ b/docs/guides/replay/via-speedctl.md
@@ -23,7 +23,7 @@ If `--namespace` is omitted and the snapshot was captured from a single namespac
 
 ### Wait for service mocks
 
-Use `speedctl wait replay` before an external test driver sends traffic. This workflow requires Speedscale v2.5.789 or newer in the cluster and `speedctl` v2.5.789 or newer on the client. Older operators do not publish the `MocksReady` condition consumed by the CLI.
+Use `speedctl wait replay` before an external test driver sends traffic. This workflow requires Speedscale v2.5.789 or newer in the cluster and `speedctl` v2.5.833 or newer on the client. Older operators do not publish the `MocksReady` condition consumed by the CLI. Older clients cannot scope the wait to the target cluster and namespace.
 
 ```bash
 REPORT_ID=$(speedctl infra replay \
@@ -36,6 +36,8 @@ REPORT_ID=$(speedctl infra replay \
 
 speedctl wait replay "$REPORT_ID" \
   --for mocks-ready \
+  --cluster {cluster_name} \
+  --namespace {namespace} \
   --timeout 10m \
   --poll-interval 5s
 ```


### PR DESCRIPTION
## Summary

- Require `speedctl` v2.5.833 or newer for the scoped wait workflow.
- Pass the replay cluster and namespace to `speedctl wait replay` in both external-driver examples.
- Keep the cluster component requirement at v2.5.789, where `MocksReady` support was introduced.

## Validation

- `git diff --check`
- Docusaurus production build
- Rendered HTML inspection for the updated version and scoped flags

[Linear issue](https://linear.app/speedscale/issue/S-12610/pega-speedctl-wait-replay-times-out-after-mocks-are-ready)