### PR TITLE
Serve real 301s for client-redirect stubs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,16 @@ jobs:
       run: yarn build
 
     - name: upload main
-      run: aws s3 sync --delete  build s3://${{ env.DOCS_BUCKET }} && aws cloudfront create-invalidation --distribution-id ${{ env.DIST_ID }} --paths '/*'
+      run: aws s3 sync --delete  build s3://${{ env.DOCS_BUCKET }}
+
+    # The sync above re-uploads the client-redirect stubs (200 + meta refresh)
+    # every deploy; replace them with website-redirect objects so the S3
+    # website endpoint answers 301 before the cache invalidation below.
+    - name: deploy redirect objects
+      run: node scripts/deploy-redirect-objects.mjs build ${{ env.DOCS_BUCKET }}
+
+    - name: invalidate cache
+      run: aws cloudfront create-invalidation --distribution-id ${{ env.DIST_ID }} --paths '/*'
 
     - name: notify on failure
       if: failure()

--- a/scripts/deploy-redirect-objects.mjs
+++ b/scripts/deploy-redirect-objects.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// Turn the client-redirect stubs in build/ into real 301s on the S3 website
+// endpoint. @docusaurus/plugin-client-redirects emits each redirect as a 200
+// HTML page with a meta refresh, which Google refuses to treat as a redirect
+// ("Page with redirect" in Search Console). Overwriting the same key with a
+// zero-byte object carrying x-amz-website-redirect-location makes the website
+// endpoint answer 301 instead.
+//
+// Runs after `aws s3 sync --delete`, which re-uploads the stubs each deploy —
+// so this must run on every deploy too.
+//
+// Usage: deploy-redirect-objects.mjs <build-dir> <bucket> [--dry-run]
+
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const [buildDir, bucket] = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+const dryRun = process.argv.includes("--dry-run");
+
+if (!buildDir || !bucket) {
+  console.error("usage: deploy-redirect-objects.mjs <build-dir> <bucket> [--dry-run]");
+  process.exit(2);
+}
+
+// A client-redirect stub is a small HTML file whose head is a meta refresh.
+// Real docs pages never carry http-equiv="refresh".
+const STUB_RE = /<meta\s+http-equiv="refresh"\s+content="0;\s*url=([^"]+)"/;
+
+const stubs = [];
+const walk = (dir) => {
+  for (const entry of readdirSync(dir)) {
+    const p = path.join(dir, entry);
+    const st = statSync(p);
+    if (st.isDirectory()) {
+      walk(p);
+    } else if (entry.endsWith(".html") && st.size < 4096) {
+      const m = readFileSync(p, "utf-8").match(STUB_RE);
+      if (m) stubs.push([path.relative(buildDir, p), m[1]]);
+    }
+  }
+};
+walk(buildDir);
+
+if (stubs.length === 0) {
+  // The plugin emitting zero stubs means the build layout changed under us.
+  console.error("no redirect stubs found in build output — layout changed?");
+  process.exit(1);
+}
+
+console.log(`${stubs.length} redirect stubs -> 301 objects in s3://${bucket}`);
+
+let failed = 0;
+// Modest parallelism: batches of 8 concurrent put-object calls.
+for (let i = 0; i < stubs.length; i += 8) {
+  const batch = stubs.slice(i, i + 8).map(async ([key, target]) => {
+    if (dryRun) {
+      console.log(`(dry-run) ${key} -> ${target}`);
+      return;
+    }
+    try {
+      execFileSync("aws", [
+        "s3api", "put-object",
+        "--bucket", bucket,
+        "--key", key,
+        "--website-redirect-location", target,
+        "--content-type", "text/html; charset=utf-8",
+        "--cache-control", "public, max-age=300",
+      ], { stdio: ["ignore", "ignore", "inherit"] });
+      console.log(`301: ${key} -> ${target}`);
+    } catch {
+      console.error(`FAILED: ${key}`);
+      failed += 1;
+    }
+  });
+  await Promise.all(batch);
+}
+
+if (failed > 0) {
+  console.error(`${failed} uploads failed`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

`@docusaurus/plugin-client-redirects` emits every redirect (390 of them) as a 200 HTML stub with a meta refresh — not a 301. Google files these under "Page with redirect" in Search Console and keeps recrawling them instead of crediting the destination. Same failure mode just fixed on www.speedscale.com.

## Solution

After `aws s3 sync`, a new deploy step scans `build/` for redirect stubs (small HTML files whose head is `<meta http-equiv="refresh">` — real docs pages never carry that) and overwrites each S3 key with a zero-byte object carrying `x-amz-website-redirect-location`. The S3 website endpoint then answers a real 301, and CloudFront (whose origin is the website endpoint) passes it through. The invalidation moves after this step so 301s go live immediately.

Scanning the build output rather than parsing `docusaurus.config.js` means every stub is covered no matter how it was configured, and the step hard-fails if it finds zero stubs — a plugin upgrade that changes the layout can't silently regress the site back to 200s.

The sync re-uploads the stubs on every deploy (it must — `--delete` would otherwise remove the keys), so the step runs on every deploy too.

## Test plan

- `yarn build` then `node scripts/deploy-redirect-objects.mjs build docs.speedscale.com --dry-run`: finds exactly **390 stubs**, matching the 390 entries in `docusaurus.config.js` — no false positives, no misses.
- Spot-checked targets: `dlp/introduction/index.html -> /guides/dlp/introduction/`, `concepts/triggers/index.html -> /guides/mocking/mocks/`, `guides/getting-started/index.html -> /`.
- Real pages (e.g. `guides/dlp/introduction`) contain no refresh meta and are not matched.
- The actual 301 behaviour is verifiable on prod after the first deploy: `curl -sI https://docs.speedscale.com/dlp/introduction/` should return `301` with `Location: /guides/dlp/introduction/`.

Note: this does not address the trailing-slash 302 (`/setup/sidecar/tls` -> 302). That needs a CloudFront Function on the docs distribution, which lives in the structure repo — separate MR.