### PR TITLE
docs: configure Java Agent storage on GKE Autopilot

### DIFF
--- a/docs/getting-started/installation/install/gke-autopilot.md
+++ b/docs/getting-started/installation/install/gke-autopilot.md
@@ -224,6 +224,13 @@ Autopilot requires that resource requests and limits match, and that every conta
 
 The `ensureMinimumEphemeralStorage` setting requires operator chart `2.5.828` or later. If your WorkloadAllowlist is pinned to an older chart, request an updated allowlist before enabling the Java Agent.
 
+Chart `2.5.828` does not restart a running operator when this value changes during a Helm upgrade. Restart the operator once so it reads the updated ConfigMap:
+
+```bash
+kubectl rollout restart deployment/speedscale-operator -n speedscale
+kubectl rollout status deployment/speedscale-operator -n speedscale
+```
+
 Verify the install:
 
 ```bash
@@ -273,7 +280,7 @@ Then upgrade the chart to the matching `--version`.
 
 For workloads that make outbound HTTPS calls, the Speedscale [Java Agent](../../../reference/languages/java.md) instruments `SSLSocketImpl` and `SSLEngineImpl` to decrypt TLS traffic.
 
-On Autopilot, install chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true` before enabling the Java Agent. This setting makes the operator add a `100Mi` `ephemeral-storage` request and limit to `speedscale-initproxy-java-agent`, which satisfies Warden admission. The setting defaults to `false` so non-Autopilot clusters keep their existing resource behavior.
+On Autopilot, install chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true` before enabling the Java Agent. This setting makes the operator add a `100Mi` `ephemeral-storage` request and limit to `speedscale-initproxy-java-agent`, which satisfies Warden admission. The setting defaults to `false` so non-Autopilot clusters keep their existing resource behavior. If you enable the setting by upgrading chart `2.5.828`, restart the operator as shown in Step 6.
 
 ## Troubleshooting
 
@@ -284,7 +291,7 @@ On Autopilot, install chart `2.5.828` or later with `ensureMinimumEphemeralStora
 | AllowlistSynchronizer not Ready | Bucket IAM, path mismatch, invalid YAML, or incompatible GKE version | Confirm `container-engine-robot` has `objectViewer` and `bucketViewer`, then inspect synchronizer status |
 | Nettap pods rejected by Warden | Resource requests and limits do not match | Reinstall with matching requests and limits |
 | Replay init containers rejected by Warden | Missing `ephemeral-storage` values | Reinstall with the `sidecar.resources.*.ephemeral-storage=100Mi` values |
-| `speedscale-initproxy-java-agent` rejected with an `ephemeral-storage` minimum such as `10Mi` | The Java Agent storage setting is disabled or the chart is older than `2.5.828` | Install chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true`, then retry the capture update |
+| `speedscale-initproxy-java-agent` rejected with an `ephemeral-storage` minimum such as `10Mi` | The Java Agent storage setting is disabled, the operator has not restarted after a chart `2.5.828` upgrade, or the chart is older than `2.5.828` | Install chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true`; on chart `2.5.828`, restart the operator, then retry the capture update |
 | Nettap image digest mismatch after a chart upgrade | Installed chart version does not match the allowlist | Install the chart `--version` that matches your `workload-allowlist.yaml`, or upload the updated allowlist from Speedscale |
 | Forwarder crashes with `FATAL: failed to get filter rule` | `filterRule=none` in the configmap | Patch it: `kubectl patch cm speedscale-forwarder -n speedscale --type merge -p '{"data":{"SPEEDSCALE_FILTER_RULE":"standard"}}'` |
 

--- a/docs/getting-started/installation/install/gke-autopilot.md
+++ b/docs/getting-started/installation/install/gke-autopilot.md
@@ -231,6 +231,26 @@ kubectl rollout restart deployment/speedscale-operator -n speedscale
 kubectl rollout status deployment/speedscale-operator -n speedscale
 ```
 
+### Workaround for an existing chart `2.5.828` installation
+
+If a Helm upgrade is difficult, add the setting to the operator override ConfigMap:
+
+```bash
+kubectl create configmap speedscale-operator-override \
+  --namespace speedscale \
+  --from-literal=ENSURE_MINIMUM_EPHEMERAL_STORAGE=true \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Restart the operator so it reads the override:
+
+```bash
+kubectl rollout restart deployment/speedscale-operator -n speedscale
+kubectl rollout status deployment/speedscale-operator -n speedscale
+```
+
+The override ConfigMap takes precedence over the Helm ConfigMap. The override remains active after a Helm upgrade.
+
 Verify the install:
 
 ```bash
@@ -291,7 +311,7 @@ On Autopilot, install chart `2.5.828` or later with `ensureMinimumEphemeralStora
 | AllowlistSynchronizer not Ready | Bucket IAM, path mismatch, invalid YAML, or incompatible GKE version | Confirm `container-engine-robot` has `objectViewer` and `bucketViewer`, then inspect synchronizer status |
 | Nettap pods rejected by Warden | Resource requests and limits do not match | Reinstall with matching requests and limits |
 | Replay init containers rejected by Warden | Missing `ephemeral-storage` values | Reinstall with the `sidecar.resources.*.ephemeral-storage=100Mi` values |
-| `speedscale-initproxy-java-agent` rejected with an `ephemeral-storage` minimum such as `10Mi` | The Java Agent storage setting is disabled, the operator has not restarted after a chart `2.5.828` upgrade, or the chart is older than `2.5.828` | Install chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true`; on chart `2.5.828`, restart the operator, then retry the capture update |
+| `speedscale-initproxy-java-agent` rejected with an `ephemeral-storage` minimum such as `10Mi` | The Java Agent storage setting is disabled, the operator has not restarted, or the chart is older than `2.5.828` | Install chart `2.5.828` or later. Set `ensureMinimumEphemeralStorage=true`, or use the override ConfigMap workaround. Restart the operator, then retry the capture update. |
 | Nettap image digest mismatch after a chart upgrade | Installed chart version does not match the allowlist | Install the chart `--version` that matches your `workload-allowlist.yaml`, or upload the updated allowlist from Speedscale |
 | Forwarder crashes with `FATAL: failed to get filter rule` | `filterRule=none` in the configmap | Patch it: `kubectl patch cm speedscale-forwarder -n speedscale --type merge -p '{"data":{"SPEEDSCALE_FILTER_RULE":"standard"}}'` |
 

--- a/docs/getting-started/installation/install/gke-autopilot.md
+++ b/docs/getting-started/installation/install/gke-autopilot.md
@@ -211,6 +211,7 @@ helm upgrade --install speedscale-operator speedscale/speedscale-operator \
   --set clusterName="${CLUSTER_NAME}" \
   --set image.registry=gcr.io/speedscale \
   --set ebpf.enabled=true \
+  --set ensureMinimumEphemeralStorage=true \
   --set 'sidecar.resources.limits.cpu=500m' \
   --set 'sidecar.resources.limits.memory=512Mi' \
   --set 'sidecar.resources.limits.ephemeral-storage=100Mi' \
@@ -219,7 +220,9 @@ helm upgrade --install speedscale-operator speedscale/speedscale-operator \
   --set 'sidecar.resources.requests.ephemeral-storage=100Mi'
 ```
 
-Autopilot requires that resource requests and limits match, and that every container declares `ephemeral-storage`. The `ephemeral-storage` values are required for Speedscale replay init containers to pass Warden admission.
+Autopilot requires that resource requests and limits match, and that every container declares `ephemeral-storage`. The sidecar values cover replay init containers. `ensureMinimumEphemeralStorage=true` adds a `100Mi` request and limit to the Java Agent init container.
+
+The `ensureMinimumEphemeralStorage` setting requires operator chart `2.5.828` or later. If your WorkloadAllowlist is pinned to an older chart, request an updated allowlist before enabling the Java Agent.
 
 Verify the install:
 
@@ -248,7 +251,7 @@ helm upgrade speedscale-operator speedscale/speedscale-operator \
 
 `--reuse-values` preserves your install values but not the chart version, so pin `--version` again here. Generate traffic against the workload, then confirm it appears in Speedscale.
 
-## Updating Speedscale Versions
+## Updating Speedscale versions
 
 The WorkloadAllowlist pins container image digests, so it must be updated in lockstep with the chart. When Speedscale provides an updated `workload-allowlist.yaml` (and its matching chart version), upload it to the same bucket path:
 
@@ -266,11 +269,11 @@ kubectl annotate allowlistsynchronizer speedscale-nettap-sync \
 
 Then upgrade the chart to the matching `--version`.
 
-## Java Agent Notes
+## Java Agent notes
 
 For workloads that make outbound HTTPS calls, the Speedscale [Java Agent](../../../reference/languages/java.md) instruments `SSLSocketImpl` and `SSLEngineImpl` to decrypt TLS traffic.
 
-On Autopilot, the operator's Java Agent init container can be rejected if the injected container does not declare explicit `ephemeral-storage` resources. Speedscale support can provide a workload-specific patch when outbound HTTPS capture is required. If you manually patch a deployment for the Java Agent, re-apply the patch after each replay, since replay cleanup restores the target deployment to its pre-replay state.
+On Autopilot, install chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true` before enabling the Java Agent. This setting makes the operator add a `100Mi` `ephemeral-storage` request and limit to `speedscale-initproxy-java-agent`, which satisfies Warden admission. The setting defaults to `false` so non-Autopilot clusters keep their existing resource behavior.
 
 ## Troubleshooting
 
@@ -281,6 +284,7 @@ On Autopilot, the operator's Java Agent init container can be rejected if the in
 | AllowlistSynchronizer not Ready | Bucket IAM, path mismatch, invalid YAML, or incompatible GKE version | Confirm `container-engine-robot` has `objectViewer` and `bucketViewer`, then inspect synchronizer status |
 | Nettap pods rejected by Warden | Resource requests and limits do not match | Reinstall with matching requests and limits |
 | Replay init containers rejected by Warden | Missing `ephemeral-storage` values | Reinstall with the `sidecar.resources.*.ephemeral-storage=100Mi` values |
+| `speedscale-initproxy-java-agent` rejected with an `ephemeral-storage` minimum such as `10Mi` | The Java Agent storage setting is disabled or the chart is older than `2.5.828` | Install chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true`, then retry the capture update |
 | Nettap image digest mismatch after a chart upgrade | Installed chart version does not match the allowlist | Install the chart `--version` that matches your `workload-allowlist.yaml`, or upload the updated allowlist from Speedscale |
 | Forwarder crashes with `FATAL: failed to get filter rule` | `filterRule=none` in the configmap | Patch it: `kubectl patch cm speedscale-forwarder -n speedscale --type merge -p '{"data":{"SPEEDSCALE_FILTER_RULE":"standard"}}'` |
 

--- a/docs/reference/helm.md
+++ b/docs/reference/helm.md
@@ -161,7 +161,7 @@ ebpf:
 
 For eBPF requirements (kernel version, capabilities, supported languages), see the [eBPF Traffic Collection reference](./ebpf-traffic-collection/README.md).
 
-### Data Loss Prevention (DLP)
+### Data loss prevention (DLP)
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -172,6 +172,7 @@ For eBPF requirements (kernel version, capabilities, supported languages), see t
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| `ensureMinimumEphemeralStorage` | bool | `false` | Adds a `100Mi` ephemeral-storage request and limit to the Java Agent init container. Set to `true` on GKE Autopilot. Available in chart `2.5.828` and later. |
 | `sidecar.resources.limits.cpu` | string | `"500m"` | CPU limit for sidecar containers. |
 | `sidecar.resources.limits.memory` | string | `"512Mi"` | Memory limit for sidecar containers. |
 | `sidecar.resources.limits.ephemeral-storage` | string | `"100Mi"` | Ephemeral storage limit for sidecar containers. |
@@ -280,7 +281,7 @@ globalLabels:
   team: "dev"
 ```
 
-### Custom Sidecar Configuration
+### Custom sidecar configuration
 
 ```yaml
 # values-sidecar.yaml

--- a/docs/reference/helm.md
+++ b/docs/reference/helm.md
@@ -172,7 +172,7 @@ For eBPF requirements (kernel version, capabilities, supported languages), see t
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `ensureMinimumEphemeralStorage` | bool | `false` | Adds a `100Mi` ephemeral-storage request and limit to the Java Agent init container. Set to `true` on GKE Autopilot. Available in chart `2.5.828` and later. |
+| `ensureMinimumEphemeralStorage` | bool | `false` | Adds a `100Mi` ephemeral-storage request and limit to the Java Agent init container. Set to `true` on GKE Autopilot. Available in chart `2.5.828` and later. Restart the operator after changing this value on chart `2.5.828`. |
 | `sidecar.resources.limits.cpu` | string | `"500m"` | CPU limit for sidecar containers. |
 | `sidecar.resources.limits.memory` | string | `"512Mi"` | Memory limit for sidecar containers. |
 | `sidecar.resources.limits.ephemeral-storage` | string | `"100Mi"` | Ephemeral storage limit for sidecar containers. |

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -15,7 +15,7 @@ Java is fully supported by Speedscale. Use this page for Java-specific proxy set
 - Shared sidecar docs: [Proxy Modes](/getting-started/installation/sidecar/proxy-modes.md) and [TLS Support](/getting-started/installation/sidecar/tls.md)
 - GKE Autopilot guidance: [GKE Autopilot](/getting-started/installation/install/gke-autopilot)
 
-## Choose Your Java Capture Mode
+## Choose your Java capture mode
 
 Quick links:
 
@@ -36,6 +36,8 @@ Workload annotations:
 capture.speedscale.com/enabled: "true"
 capture.speedscale.com/java-agent: "true"
 ```
+
+GKE Autopilot also requires operator chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true`. See the [GKE Autopilot install guide](/getting-started/installation/install/gke-autopilot#6-install-speedscale-with-ebpf).
 
 :::warning
 `capture.speedscale.com/java-agent: "true"` is mutually exclusive with

--- a/docs/reference/languages/java.md
+++ b/docs/reference/languages/java.md
@@ -37,7 +37,7 @@ capture.speedscale.com/enabled: "true"
 capture.speedscale.com/java-agent: "true"
 ```
 
-GKE Autopilot also requires operator chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true`. See the [GKE Autopilot install guide](/getting-started/installation/install/gke-autopilot#6-install-speedscale-with-ebpf).
+GKE Autopilot also requires operator chart `2.5.828` or later with `ensureMinimumEphemeralStorage=true`. Restart the operator after changing this value on chart `2.5.828`. See the [GKE Autopilot install guide](/getting-started/installation/install/gke-autopilot#6-install-speedscale-with-ebpf).
 
 :::warning
 `capture.speedscale.com/java-agent: "true"` is mutually exclusive with


### PR DESCRIPTION
## Summary

- Add `ensureMinimumEphemeralStorage=true` to the GKE Autopilot installation command.
- Document the 100Mi Java Agent init-container request and the chart version requirement.
- Document the operator restart required when chart 2.5.828 changes the setting during an upgrade.
- Add the GKE Warden rejection to troubleshooting and cross-link the Helm and Java references.

## Testing

- `yarn build`
- Public-writing checks for all three changed pages
