### PR TITLE
ci: keep prod AWS credentials out of scope during install and build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,47 +20,58 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
       with:
         fetch-depth: 0
 
-    - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v5
-      with:
-        role-to-assume: ${{ env.AWS_ROLE }}
-        aws-region: ${{ env.AWS_REGION }}
-
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version: '22'
+        cache: yarn
 
     - name: install
-      uses: bahmutov/npm-install@v1
-      with:
-        install-command: yarn --frozen-lockfile --silent
+      run: yarn --frozen-lockfile --silent
 
     - name: check redirects
-      run: node scripts/check-redirects.mjs ${{ github.before }}
+      env:
+        BASE_SHA: ${{ github.before }}
+      run: node scripts/check-redirects.mjs "$BASE_SHA"
 
     - name: build
       run: yarn build
 
+    # AWS credentials are configured as late as possible, immediately before the
+    # first step that needs them. Everything above this point executes code we do
+    # not control -- npm lifecycle hooks during install, and Docusaurus/webpack
+    # plugins across the whole dependency tree during build. Credentials placed
+    # ahead of those steps are readable by any one of them, and this role can
+    # `s3 sync --delete` the production bucket.
+    - name: configure aws credentials
+      uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.0.0
+      with:
+        role-to-assume: ${{ env.AWS_ROLE }}
+        aws-region: ${{ env.AWS_REGION }}
+
     - name: upload main
-      run: aws s3 sync --delete  build s3://${{ env.DOCS_BUCKET }}
+      run: aws s3 sync --delete build "s3://$DOCS_BUCKET"
 
     # The sync above re-uploads the client-redirect stubs (200 + meta refresh)
     # every deploy; replace them with website-redirect objects so the S3
     # website endpoint answers 301 before the cache invalidation below.
     - name: deploy redirect objects
-      run: node scripts/deploy-redirect-objects.mjs build ${{ env.DOCS_BUCKET }}
+      run: node scripts/deploy-redirect-objects.mjs build "$DOCS_BUCKET"
 
     - name: invalidate cache
-      run: aws cloudfront create-invalidation --distribution-id ${{ env.DIST_ID }} --paths '/*'
+      run: aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths '/*'
 
     - name: notify on failure
       if: failure()
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        REF_NAME: ${{ github.ref_name }}
+        REPOSITORY: ${{ github.repository }}
       run: |
-        curl -X POST -H 'Content-type: application/json' \
-          --data '{"text":"I am pretty sad right now guys. My build is failing on *'${{ github.ref_name }}'* in repository *'${{ github.repository }}'*.  Please check on me soon."}' \
-          ${{ secrets.SLACK_WEBHOOK_URL }}
+        payload=$(jq -n --arg ref "$REF_NAME" --arg repo "$REPOSITORY" \
+          '{text: "I am pretty sad right now guys. My build is failing on *\($ref)* in repository *\($repo)*.  Please check on me soon."}')
+        curl -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,43 +20,52 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
       with:
         fetch-depth: 0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version: '22'
+        cache: yarn
 
     - name: install
-      uses: bahmutov/npm-install@v1
-      with:
-        install-command: yarn --frozen-lockfile --silent
+      run: yarn --frozen-lockfile --silent
 
     - name: check redirects
-      run: node scripts/check-redirects.mjs ${{ github.event.pull_request.base.sha }}
-
-    - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v5
-      with:
-        role-to-assume: ${{ env.AWS_ROLE }}
-        aws-region: ${{ env.AWS_REGION }}
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: node scripts/check-redirects.mjs "$BASE_SHA"
 
     - name: update url for preview
-      run: ./tools/update_preview_base.sh pr-${{ github.event.pull_request.number }}
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: ./tools/update_preview_base.sh "pr-$PR_NUMBER"
 
     - name: build
       run: yarn build
 
+    # Configured after install and build so the credentials are not in scope
+    # while third-party code runs. See the same note in main.yaml.
+    - name: configure aws credentials
+      uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.0.0
+      with:
+        role-to-assume: ${{ env.AWS_ROLE }}
+        aws-region: ${{ env.AWS_REGION }}
+
     - name: upload preview
-      run: aws s3 sync build s3://${{ env.DOWNLOADS_PREVIEW_BUCKET }}/pr-${{ github.event.pull_request.number }}
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: aws s3 sync build "s3://$DOWNLOADS_PREVIEW_BUCKET/pr-$PR_NUMBER"
 
     - name: show url
-      run: echo 'http://${{ env.DOWNLOADS_PREVIEW_BUCKET }}.s3-website-us-east-1.amazonaws.com/pr-${{ github.event.pull_request.number }}/'
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: echo "http://$DOWNLOADS_PREVIEW_BUCKET.s3-website-us-east-1.amazonaws.com/pr-$PR_NUMBER/"
 
     - name: Find Comment
-      uses: peter-evans/find-comment@v2
+      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -64,7 +73,7 @@ jobs:
         body-includes: Preview available at 'http://${{ env.DOWNLOADS_PREVIEW_BUCKET }}.s3-website-us-east-1.amazonaws.com/pr-${{ github.event.pull_request.number }}/'
 
     - name: Create or Update comment
-      uses: peter-evans/create-or-update-comment@v2
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }} # This will be empty and a new comment will be made if no comment already exists
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr_cleanup.yaml
+++ b/.github/workflows/pr_cleanup.yaml
@@ -19,10 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.0.0
       with:
         role-to-assume: ${{ env.AWS_ROLE }}
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Delete PR preview
-      run: aws s3 rm --recursive s3://${{ env.DOWNLOADS_PREVIEW_BUCKET }}/pr-${{ github.event.pull_request.number }}
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: aws s3 rm --recursive "s3://$DOWNLOADS_PREVIEW_BUCKET/pr-$PR_NUMBER"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.1",
     "@docusaurus/types": "^3.10.1",
-    "husky": "^9.1.7",
-    "patch-package": "^8.0.1"
+    "husky": "^9.1.7"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/scripts/check-redirects.mjs
+++ b/scripts/check-redirects.mjs
@@ -12,7 +12,7 @@
  */
 
 import { readFileSync, existsSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { cwd } from "node:process";
 
@@ -43,11 +43,14 @@ function parseRedirects(configContent) {
 
 /** Get changed files by diff-filter status */
 function getChangedFiles(filter, baseRef) {
+  // execFileSync, not execSync: baseRef comes from argv, so a value containing
+  // shell metacharacters would otherwise be interpreted by a shell. Passing an
+  // argv array keeps it a single opaque argument to git.
   const args = baseRef
-    ? `git diff --diff-filter=${filter} --name-only HEAD...${baseRef}`
-    : `git diff --diff-filter=${filter} --name-only --cached`;
+    ? ["diff", `--diff-filter=${filter}`, "--name-only", `HEAD...${baseRef}`]
+    : ["diff", `--diff-filter=${filter}`, "--name-only", "--cached"];
   try {
-    const files = execSync(args, { cwd: WORK_DIR, encoding: "utf-8" })
+    const files = execFileSync("git", args, { cwd: WORK_DIR, encoding: "utf-8" })
       .trim()
       .split("\n")
       .filter(Boolean);

--- a/scripts/deploy-redirect-objects.mjs
+++ b/scripts/deploy-redirect-objects.mjs
@@ -48,6 +48,21 @@ if (stubs.length === 0) {
   process.exit(1);
 }
 
+// Every target here becomes an x-amz-website-redirect-location, which S3 will
+// serve as a 301 to wherever it points — including off-site. All of our
+// configured redirects are site-relative, so anything else means the build
+// produced something we did not intend; fail rather than publish an open
+// redirect on docs.speedscale.com. Note "//host" is protocol-relative and
+// leaves the origin, so a leading-slash check alone is not enough.
+const offsite = stubs.filter(
+  ([, target]) => !target.startsWith("/") || target.startsWith("//"),
+);
+if (offsite.length > 0) {
+  console.error("refusing to publish non-relative redirect targets:");
+  for (const [key, target] of offsite) console.error(`  ${key} -> ${target}`);
+  process.exit(1);
+}
+
 console.log(`${stubs.length} redirect stubs -> 301 objects in s3://${bucket}`);
 
 let failed = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3346,11 +3346,6 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@yarnpkg/lockfile@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
-  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
-
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -3772,7 +3767,7 @@ call-bind@^1.0.8:
     get-intrinsic "^1.3.0"
     set-function-length "^1.2.2"
 
-call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
+call-bound@^1.0.2, call-bound@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
   integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
@@ -3910,7 +3905,7 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz#05bffd7ff928465093314708c93bdfa9bd1f0f5b"
   integrity sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==
 
-ci-info@^3.2.0, ci-info@^3.7.0:
+ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
@@ -5362,13 +5357,6 @@ find-up@^6.3.0:
     locate-path "^7.1.0"
     path-exists "^5.0.0"
 
-find-yarn-workspace-root@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
-  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
-  dependencies:
-    micromatch "^4.0.2"
-
 flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
@@ -5403,15 +5391,6 @@ fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
-
-fs-extra@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
-  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
 
 fs-extra@^11.1.1, fs-extra@^11.2.0:
   version "11.4.0"
@@ -5552,7 +5531,7 @@ graceful-fs@4.2.10:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -6171,7 +6150,7 @@ is-typedarray@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
 
-is-wsl@^2.1.1, is-wsl@^2.2.0:
+is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -6194,11 +6173,6 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
-
-isarray@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -6299,17 +6273,6 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-stable-stringify@^1.0.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz#8903cfac42ea1a0f97f35d63a4ce0518f0cc6a70"
-  integrity sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==
-  dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.4"
-    isarray "^2.0.5"
-    jsonify "^0.0.1"
-    object-keys "^1.1.1"
-
 json5@^2.1.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -6323,11 +6286,6 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonify@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
-  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
 katex@^0.16.45:
   version "0.16.47"
@@ -6352,13 +6310,6 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
-
-klaw-sync@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
-  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
-  dependencies:
-    graceful-fs "^4.1.11"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -7213,7 +7164,7 @@ micromark@^4.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
-micromatch@^4.0.2, micromatch@^4.0.5, micromatch@^4.0.8:
+micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -7297,7 +7248,7 @@ minimatch@3.1.5:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@^1.2.0:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -7476,14 +7427,6 @@ open@^10.0.3:
     is-inside-container "^1.0.0"
     wsl-utils "^0.1.0"
 
-open@^7.4.2:
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
-  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
-  dependencies:
-    is-docker "^2.0.0"
-    is-wsl "^2.1.1"
-
 open@^8.4.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
@@ -7645,26 +7588,6 @@ pascal-case@^3.1.2:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
-
-patch-package@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.1.tgz#79d02f953f711e06d1f8949c8a13e5d3d7ba1a60"
-  integrity sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==
-  dependencies:
-    "@yarnpkg/lockfile" "^1.1.0"
-    chalk "^4.1.2"
-    ci-info "^3.7.0"
-    cross-spawn "^7.0.3"
-    find-yarn-workspace-root "^2.0.0"
-    fs-extra "^10.0.0"
-    json-stable-stringify "^1.0.2"
-    klaw-sync "^6.0.0"
-    minimist "^1.2.6"
-    open "^7.4.2"
-    semver "^7.5.3"
-    slash "^2.0.0"
-    tmp "^0.2.4"
-    yaml "^2.2.2"
 
 path-data-parser@0.1.0, path-data-parser@^0.1.0:
   version "0.1.0"
@@ -8969,7 +8892,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
+semver@^7.3.5, semver@^7.3.7, semver@^7.5.4:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
@@ -9155,11 +9078,6 @@ skin-tone@^2.0.0:
   integrity sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==
   dependencies:
     unicode-emoji-modifier-base "^1.0.0"
-
-slash@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
-  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -9466,7 +9384,7 @@ tinypool@^1.0.2:
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
   integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
 
-tmp@^0.2.4, tmp@^0.2.7:
+tmp@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
   integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
@@ -10000,11 +9918,6 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yaml@^2.2.2:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
-  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yocto-queue@^1.0.0:
   version "1.2.2"


### PR DESCRIPTION
Fixes the highest-risk item from a security review of this repo. Linear: [S-12784](https://linear.app/speedscale/issue/S-12784/harden-docs-deploy-pipeline-prod-aws-creds-exposed-to-npm-tree-and)

## The main problem

`main.yaml` configured AWS credentials as **step 2**, before install and build. Everything after that ran with live production credentials in the environment:

- `bahmutov/npm-install@v1` — a third-party action tracked by a **branch ref**, not even a tag
- `postinstall: node ./scripts/apply-patch.mjs`
- `yarn build` — plugin code across ~1,339 packages

That role can `aws s3 sync --delete` the prod bucket and invalidate CloudFront. One compromised transitive dependency, or a force-pushed `v1` branch, was enough to deface docs.speedscale.com.

This moves the credentials step to sit immediately before the first step that actually needs it, in both `main.yaml` and `pr.yaml`. Nothing between checkout and the S3 upload executes third-party code anymore.

To be clear about what this was *not*: fork PRs could never reach the role. Public repo on `pull_request` (not `pull_request_target`) means secrets are withheld and `id-token: write` is downgraded. The realistic threat here is dependency/action compromise, not drive-by fork attacks.

## Also in this PR

**Action pinning.** Every `uses:` is now a full commit SHA with the version in a trailing comment.

Two judgment calls worth a look:

1. `peter-evans/find-comment` and `create-or-update-comment` were on `v2`, which runs **node16** — no longer supported on current runners. Pinning those SHAs would have frozen an action that is already broken or force-upgraded underneath us, so they move to `v4.0.0` / `v5.0.0` (both node24). Inputs and outputs used here are unchanged across those majors.
2. **`bahmutov/npm-install` is removed** rather than pinned, replaced by `setup-node`'s built-in `cache: yarn` plus a plain `yarn --frozen-lockfile --silent`. Pinning it would have been the minimal fix; removing it takes a third-party action out of a credentialed pipeline entirely. This is the one non-mechanical change here — if you'd rather keep it, pin `20216767ca67f0f7b4d095dc5859c5700a6581cb` instead and I'll revert this part.

**Injection-pattern cleanup.** Workflow inputs now go through `env:` instead of being interpolated into `run:` bodies, and `check-redirects.mjs` uses `execFileSync` instead of `execSync`. Neither was reachable — the inputs are commit SHAs and a branch filtered to `main` — but the pattern is worth not having.

**Open-redirect guard.** `deploy-redirect-objects.mjs` lifts a URL out of built HTML into `--website-redirect-location`, which S3 serves as a 301 to wherever it points. All 390 configured redirects are site-relative and the `size < 4096` guard excludes real doc pages, so this was not exploitable — but the script now refuses anything that isn't site-relative. The check rejects protocol-relative `//host` too, since that leaves the origin despite the leading slash.

**`patch-package` removed.** Declared in `devDependencies`, but there is no `patches/` directory and nothing invokes it. The actual bundler patching is the hand-rolled `scripts/apply-patch.mjs`. Removing it drops ~10 packages from the tree; the `yarn.lock` delta is that and nothing else.

## Verification

- `yarn build` succeeds, and the "Compiling Client / Build completed" output confirms `apply-patch.mjs` still applies (those lines come from the patched progress plugin).
- `check-redirects.mjs HEAD~5` → clean.
- `deploy-redirect-objects.mjs build ... --dry-run` → all 376 stubs pass.
- Negative test on the new guard: `https://evil.example.com/` and `//evil.example.com/` are both rejected with exit 1, while a site-relative target passes.
- All three workflow files parse as valid YAML.

CI on this PR exercises the reordered `pr.yaml` path directly.

## Follow-ups (already filed)

- [S-12785](https://linear.app/speedscale/issue/S-12785/add-cloudfront-security-response-headers-for-docsspeedscalecom) — docs.speedscale.com returns no security headers at all (HSTS, CSP, nosniff, frame-ancestors)
- [S-12786](https://linear.app/speedscale/issue/S-12786/docs-pr-previews-served-over-plaintext-http-from-a-public-s3-website) — PR previews served over plaintext HTTP from a public bucket
- [S-12787](https://linear.app/speedscale/issue/S-12787/add-dependabotyml-and-codeowners-to-the-docs-repo) — `dependabot.yml` + `CODEOWNERS`. Worth pairing with this PR: SHA-pinning without an updater means the pins rot silently.
- [S-12788](https://linear.app/speedscale/issue/S-12788/credential-hygiene-in-docs-verify-aws-key-id-re-scope-algolia-search) — credential hygiene
- [S-12789](https://linear.app/speedscale/issue/S-12789/track-image-size-dos-advisories-no-upstream-patch-available) / [S-12790](https://linear.app/speedscale/issue/S-12790/migrate-docs-off-yarn-classic-122-eol-to-yarn-berry) — `image-size` tracking, Yarn Berry migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
