### PR TITLE
ci: add dependabot config and CODEOWNERS for sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# Code owners for security-sensitive paths in this repo.
+#
+# Deliberately not a catch-all: ordinary docs changes under docs/ do not need
+# an owner. These entries cover the files that either run inside the deploy
+# pipeline or change what every visitor's browser executes.
+#
+# Owners are listed individually rather than as @speedscale/devs because a
+# CODEOWNERS entry naming a principal without write access to the repo is
+# silently ignored by GitHub -- no error, no protection.
+
+# Workflows, the Dependabot config, and this file itself. main.yaml holds the
+# credentials that can sync and delete the production docs bucket.
+.github/**              @kenahrens @mleray24 @shaunduncan
+
+# Dependency manifests. The build executes code from every package here.
+package.json            @kenahrens @mleray24 @shaunduncan
+yarn.lock               @kenahrens @mleray24 @shaunduncan
+
+# Scripts invoked by CI: check-redirects, deploy-redirect-objects (which writes
+# S3 redirect objects), apply-patch (which runs on every install), and
+# update_preview_base.sh.
+scripts/**              @kenahrens @mleray24 @shaunduncan
+tools/**                @kenahrens @mleray24 @shaunduncan
+
+# headTags in this file injects raw <script> into every page on the site, and
+# the redirect table drives what deploy-redirect-objects.mjs publishes.
+docusaurus.config.js    @kenahrens @mleray24 @shaunduncan

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+
+updates:
+  # Actions in this repo are pinned to commit SHAs. Pinning without an updater
+  # just trades a supply-chain risk for a staleness one -- the pins freeze on
+  # deprecated runtimes and nobody notices. Dependabot rewrites both the SHA
+  # and the trailing "# vX.Y.Z" comment, which is what keeps the pins honest.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+    labels:
+      - "dependencies"
+    # Groups are matched in order, so the specific ones must precede the
+    # catch-all below.
+    groups:
+      # The @docusaurus/* packages are version-locked to each other. Splitting
+      # them across separate PRs produces combinations that will not install.
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+          - "@mdx-js/*"
+          - "prism-react-renderer"
+      algolia:
+        patterns:
+          - "@docsearch/*"
+          - "algoliasearch"
+      babel:
+        patterns:
+          - "@babel/*"
+      # Everything else: routine minor/patch churn arrives as one PR a week.
+      # Majors are deliberately excluded so they still show up individually
+      # and get reviewed on their own merits.
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -46,25 +46,35 @@ jobs:
     - name: build
       run: yarn build
 
-    # Configured after install and build so the credentials are not in scope
-    # while third-party code runs. See the same note in main.yaml.
+    # Everything below publishes the preview and needs AWS + write access.
+    #
+    # Dependabot-authored PRs run with the Dependabot secrets store, not the
+    # Actions one, so `secrets.AWS_ROLE` is empty for them and the credentials
+    # step would fail on every dependency bump. Their GITHUB_TOKEN is read-only
+    # too, so the comment steps could not post either. Skipping the publish for
+    # Dependabot keeps checkout/install/build running -- which is the part that
+    # actually validates the bump -- without a guaranteed red X.
     - name: configure aws credentials
+      if: github.actor != 'dependabot[bot]'
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.0.0
       with:
         role-to-assume: ${{ env.AWS_ROLE }}
         aws-region: ${{ env.AWS_REGION }}
 
     - name: upload preview
+      if: github.actor != 'dependabot[bot]'
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: aws s3 sync build "s3://$DOWNLOADS_PREVIEW_BUCKET/pr-$PR_NUMBER"
 
     - name: show url
+      if: github.actor != 'dependabot[bot]'
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: echo "http://$DOWNLOADS_PREVIEW_BUCKET.s3-website-us-east-1.amazonaws.com/pr-$PR_NUMBER/"
 
     - name: Find Comment
+      if: github.actor != 'dependabot[bot]'
       uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
       id: fc
       with:
@@ -73,6 +83,7 @@ jobs:
         body-includes: Preview available at 'http://${{ env.DOWNLOADS_PREVIEW_BUCKET }}.s3-website-us-east-1.amazonaws.com/pr-${{ github.event.pull_request.number }}/'
 
     - name: Create or Update comment
+      if: github.actor != 'dependabot[bot]'
       uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }} # This will be empty and a new comment will be made if no comment already exists

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "katex": "^0.16.45",
     "fast-uri": "^3.1.2",
     "serialize-javascript": "^7.0.5",
-    "tmp": "^0.2.7",
     "mermaid": "^11.15.0",
     "qs": "^6.15.2",
     "uuid": "^14.0.1",


### PR DESCRIPTION
Follow-on to #735. Linear: [S-12787](https://linear.app/speedscale/issue/S-12787/add-dependabotyml-and-codeowners-to-the-docs-repo)

> **Stacked on #735** — base is `security/harden-deploy-pipeline`, so review this as the diff on top. GitHub will retarget it to `main` automatically when #735 merges.

#735 pinned every action to a commit SHA. That trades a supply-chain risk for a staleness one: pins freeze on deprecated runtimes and nobody notices. (#735's own CI already surfaced one — `aws-actions/configure-aws-credentials` is on node20.) This adds the updater that keeps the pins honest, plus a path-aware review gate.

## What's here

**`.github/dependabot.yml`** — npm and github-actions, weekly.

Groups are ordered specific-first, since Dependabot matches in order:
- `@docusaurus/*` are version-locked to each other; splitting them across PRs produces combinations that won't install
- `algolia`, `babel` grouped similarly
- a `minor-and-patch` catch-all keeps routine churn to one PR a week, while **majors still arrive individually** so they get reviewed on their own merits

**`.github/CODEOWNERS`** — deliberately *not* a catch-all. Ordinary `docs/` changes don't need an owner. It covers the files that either run inside the deploy pipeline or change what every visitor's browser executes: `.github/**`, `package.json`, `yarn.lock`, `scripts/**`, `tools/**`, and `docusaurus.config.js`.

Two of those go slightly beyond the obvious list, so flag them if you disagree:
- `tools/**` — `update_preview_base.sh` runs in `pr.yaml`
- `docusaurus.config.js` — its `headTags` block injects raw `<script>` into every page on the site, and its redirect table drives what `deploy-redirect-objects.mjs` publishes to S3

Owners are listed individually rather than as `@speedscale/devs`. A CODEOWNERS entry naming a principal without write access to the repo is **silently ignored** by GitHub — no error, no protection — and team-to-repo access can't be verified without `admin:org` scope. Individual handles were verified against the collaborators API, and GitHub's own validator returns clean:

```
$ gh api "repos/speedscale/docs/codeowners/errors?ref=security/dependency-automation"
{"errors":[]}
```

**`pr.yaml`: skip the preview publish for Dependabot PRs.** This is the part that makes Dependabot usable here rather than a source of permanent red X's.

Dependabot-authored PRs run against the *Dependabot* secrets store, not the Actions one, so `secrets.AWS_ROLE` is empty and `configure aws credentials` would fail on every single dependency bump. Their `GITHUB_TOKEN` is read-only, so the comment steps couldn't post either.

The guard boundary lines up exactly with the credential boundary #735 established — checkout, install, `check redirects` and `build` all still run for Dependabot, which is the part that actually validates the bump. Only the publish is skipped.

## Note on the ruleset

`main` is protected by a ruleset requiring a PR plus 1 approval, but with `require_code_owner_review: false` — so CODEOWNERS alone would only *auto-request* reviewers, not require them. Matt approved enabling it; I'm flipping that setting separately from this PR since it's a live repo-settings change, not a file.

It takes effect only once this CODEOWNERS lands on `main` (the rule evaluates against the base branch's file). The release-notes bot is unaffected — it bypasses the ruleset through a DeployKey with `bypass_mode: always`. Practical effect: `alanspeedscale` can no longer be sole approver on workflow or dependency changes.

## Correction to the original review

My first pass reported "no required reviewer" on these paths. That was imprecise — a PR plus 1 approval was already required. What's missing is specifically that review isn't *path-aware*. Smaller gap than I described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Added: resolutions audit (ticket item 4)

Tested empirically rather than by inspection — re-resolved the whole tree with all 18 pins stripped and diffed the result. **6 of 18 pins actually change what gets installed:**

| Pin | With | Without |
|---|---|---|
| `cheerio` | `1.2.0` | `1.0.0-rc.12` + `1.2.0` (two copies) |
| `http-proxy-middleware` | `3.0.7` | `2.0.10` |
| `serialize-javascript` | `7.1.0` | `6.0.2` |
| `uuid` | `14.0.1` | `14.0.1` + `8.3.2` |
| `ws` | `8.21.3` | `7.5.13` + `8.21.3` |
| `tmp` | `0.2.7` | *(absent)* |

**`tmp` is removed in this PR.** It entered the tree via `patch-package`, which #735 takes out. Nothing depends on it now, so the pin was the only thing keeping it in `yarn.lock`, and it isn't present in `node_modules`.

The other **12 pins are no-ops today** — semver already lands on the same version without them. I've left them in place rather than cleaning house: they function as minimum-version floors, which is cheap insurance if a future transitive change starts requesting something older. They're better revisited during the Berry migration ([S-12790](https://linear.app/speedscale/issue/S-12790/migrate-docs-off-yarn-classic-122-eol-to-yarn-berry)), when the lockfile regenerates wholesale and a stale floor would actually matter.

Two caveats worth knowing:
- yarn 1 doesn't prune orphaned lockfile entries on an incremental install, so the `tmp` block stays in `yarn.lock` until the next full re-resolve. It's inert, and I verified `yarn install --frozen-lockfile` still exits 0 — CI won't break.
- The `image-size` pin is among the 12 no-ops, and worth noting it buys nothing security-wise either: there's no patched version upstream ([S-12789](https://linear.app/speedscale/issue/S-12789/track-image-size-dos-advisories-no-upstream-patch-available)).
