### PR TITLE
docs: use AWS's placeholder key ID in the aws_auth example

### DIFF
--- a/docs/guides/transformation/transforms/aws_auth.md
+++ b/docs/guides/transformation/transforms/aws_auth.md
@@ -104,7 +104,7 @@ The transform reports both `idPath` and `secretPath` to the operator as required
 Given a recorded request with:
 
 ```
-Authorization: AWS4-HMAC-SHA256 Credential=AKIARMCVI5QDT57Y4NSL/20250505/us-east-1/firehose/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-length;content-type;host;x-amz-date;x-amz-target, Signature=foozibar
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20250505/us-east-1/firehose/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-length;content-type;host;x-amz-date;x-amz-target, Signature=foozibar
 x-amz-date: 20250505T232121Z
 ```
 


### PR DESCRIPTION
Partial fix for [S-12788](https://linear.app/speedscale/issue/S-12788/credential-hygiene-in-docs-verify-aws-key-id-re-scope-algolia-search). One-line change, independent of #735 and #736 — targets `main` directly.

## What

`docs/guides/transformation/transforms/aws_auth.md` carried `AKIARMCVI5QDT57Y4NSL` in its SigV4 example. That has the shape of a real long-term IAM user key ID — and given this product records live traffic, it was plausibly lifted from an actual recording.

No secret key accompanied it (the signature is `foozibar`), so it was never usable on its own. But an `AKIA` value identifies a real AWS account and principal, which is useful for reconnaissance, and **this repo is public**.

Replaced with `AKIAIOSFODNN7EXAMPLE`, the placeholder AWS uses throughout its own SigV4 docs.

## Scope

This was the only occurrence in the working tree. The old `docs/transform/transforms/aws_auth.md` path that also carried it no longer exists. A sweep for other credential shapes across `docs/`, `src/` and `static/` — Google, Stripe, npm, Azure connection strings, GitHub tokens, AWS-secret-shaped strings — came back empty.

Worth noting the value is still in git history and in previously-committed `build/` output. I'd treat that as an argument for deactivating the key rather than for rewriting history on a public repo.

## This does not close the ticket

Two things still need a human with console access:

1. **Confirm the original key ID is deactivated.** I can't check IAM from here. This is the part that actually matters — the doc change removes the signpost, not the exposure.
2. **Reissue the Algolia key as search-only.** Its live ACL is `["search","listIndexes","settings"]`; DocSearch needs only `search`. Disclosure-only impact (index names and configuration), no write access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
